### PR TITLE
Use dh_eoscontent to merge Endless desktop customizations

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Vcs-Bzr: https://code.launchpad.net/~chromium-team/chromium-browser/trusty-worki
 Homepage: http://code.google.com/chromium/
 Build-Depends:
 	debhelper (>= 9),
+	eos-shell-content-dev,
 	dh-buildinfo,
 	ninja-build (>= 1.3),
 	pkg-config,

--- a/debian/rules
+++ b/debian/rules
@@ -256,7 +256,7 @@ endif
 # Debian Policy §4.9
 binary binary-arch binary-indep build build-arch build-indep clean install install-arch install-indep patch:
 	@set -eux
-	dh --sourcedirectory=$(DEB_TAR_SRCDIR) --builddirectory=$(DEB_TAR_SRCDIR)/out/$(BUILD_TYPE) --with quilt $@
+	dh --sourcedirectory=$(DEB_TAR_SRCDIR) --builddirectory=$(DEB_TAR_SRCDIR)/out/$(BUILD_TYPE) --with quilt,eoscontent $@
 
 # BZR build-deb rule
 get-packaged-orig-source: URL=https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$(ORIG_VERSION).tar.xz


### PR DESCRIPTION
Include dh_eoscontent from eos-shell-content-dev in the debhelper
sequence to merge Endless content changes in the desktop file.

[endlessm/eos-shell#5272]