### PR TITLE
Drain fix

### DIFF
--- a/content/common/gpu/media/v4l2_video_decode_accelerator.cc
+++ b/content/common/gpu/media/v4l2_video_decode_accelerator.cc
@@ -167,11 +167,11 @@ V4L2VideoDecodeAccelerator::V4L2VideoDecodeAccelerator(
       decoder_thread_("V4L2DecoderThread"),
       decoder_state_(kUninitialized),
       device_(device.Pass()),
-      decoder_delay_bitstream_buffer_id_(-1),
       decoder_current_input_buffer_(-1),
       decoder_decode_buffer_tasks_scheduled_(0),
       decoder_frames_at_client_(0),
       decoder_flushing_(false),
+      decoder_flushed_(false),
       resolution_change_pending_(false),
       resolution_change_reset_pending_(false),
       decoder_partial_frame_pending_(false),
@@ -469,15 +469,7 @@ void V4L2VideoDecodeAccelerator::DecodeTask(
   }
   DVLOG(3) << "DecodeTask(): mapped at=" << bitstream_record->shm->memory();
 
-  if (decoder_state_ == kResetting || decoder_flushing_) {
-    // In the case that we're resetting or flushing, we need to delay decoding
-    // the BitstreamBuffers that come after the Reset() or Flush() call.  When
-    // we're here, we know that this DecodeTask() was scheduled by a Decode()
-    // call that came after (in the client thread) the Reset() or Flush() call;
-    // thus set up the delay if necessary.
-    if (decoder_delay_bitstream_buffer_id_ == -1)
-      decoder_delay_bitstream_buffer_id_ = bitstream_record->input_id;
-  } else if (decoder_state_ == kError) {
+  if (decoder_state_ == kError) {
     DVLOG(2) << "DecodeTask(): early out: kError state";
     return;
   }
@@ -513,7 +505,7 @@ void V4L2VideoDecodeAccelerator::DecodeBufferTask() {
       return;
     }
     linked_ptr<BitstreamBufferRef>& buffer_ref = decoder_input_queue_.front();
-    if (decoder_delay_bitstream_buffer_id_ == buffer_ref->input_id) {
+    if (decoder_flushed_) {
       // We're asked to delay decoding on this and subsequent buffers.
       return;
     }
@@ -1085,6 +1077,7 @@ void V4L2VideoDecodeAccelerator::Dequeue() {
     if (dqbuf.m.planes[0].bytesused + dqbuf.m.planes[1].bytesused == 0) {
       // This is an empty output buffer returned as part of a flush.
       free_output_buffers_.push(dqbuf.index);
+      decoder_flushed_ = true;
     } else {
       DCHECK_GE(dqbuf.timestamp.tv_sec, 0);
       output_record.at_client = true;
@@ -1259,28 +1252,17 @@ void V4L2VideoDecodeAccelerator::FlushTask() {
       linked_ptr<BitstreamBufferRef>(new BitstreamBufferRef(
           io_client_, io_message_loop_proxy_, NULL, 0, kFlushBufferId)));
   decoder_flushing_ = true;
+  decoder_flushed_ = false;
   SendPictureReady();  // Send all pending PictureReady.
 
   ScheduleDecodeBufferTaskIfNeeded();
 }
 
 void V4L2VideoDecodeAccelerator::NotifyFlushDoneIfNeeded() {
-  if (!decoder_flushing_)
+  if (!decoder_flushing_ || !decoder_flushed_)
     return;
 
-  // Pipeline is empty when:
-  // * Decoder input queue is empty of non-delayed buffers.
-  // * There is no currently filling input buffer.
-  // * Input holding queue is empty.
-  // * All input (VIDEO_OUTPUT) buffers are returned.
-  if (!decoder_input_queue_.empty()) {
-    if (decoder_input_queue_.front()->input_id !=
-        decoder_delay_bitstream_buffer_id_)
-      return;
-  }
   if (decoder_current_input_buffer_ != -1)
-    return;
-  if ((input_ready_queue_.size() + input_buffer_queued_count_) != 0)
     return;
 
   // TODO(posciak): crbug.com/270039. Exynos requires a streamoff-streamon
@@ -1298,7 +1280,6 @@ void V4L2VideoDecodeAccelerator::NotifyFlushDoneIfNeeded() {
   if (!StartDevicePoll())
     return;
 
-  decoder_delay_bitstream_buffer_id_ = -1;
   decoder_flushing_ = false;
   DVLOG(3) << "NotifyFlushDoneIfNeeded(): returning flush";
   child_message_loop_proxy_->PostTask(
@@ -1387,7 +1368,6 @@ void V4L2VideoDecodeAccelerator::ResetDoneTask() {
   }
 
   decoder_partial_frame_pending_ = false;
-  decoder_delay_bitstream_buffer_id_ = -1;
   child_message_loop_proxy_->PostTask(FROM_HERE, base::Bind(
       &Client::NotifyResetDone, client_));
 

--- a/content/common/gpu/media/v4l2_video_decode_accelerator.h
+++ b/content/common/gpu/media/v4l2_video_decode_accelerator.h
@@ -339,10 +339,6 @@ class CONTENT_EXPORT V4L2VideoDecodeAccelerator
   scoped_ptr<BitstreamBufferRef> decoder_current_bitstream_buffer_;
   // The V4L2Device this class is operating upon.
   scoped_ptr<V4L2Device> device_;
-  // FlushTask() and ResetTask() should not affect buffers that have been
-  // queued afterwards.  For flushing or resetting the pipeline then, we will
-  // delay these buffers until after the flush or reset completes.
-  int decoder_delay_bitstream_buffer_id_;
   // Input buffer we're presently filling.
   int decoder_current_input_buffer_;
   // We track the number of buffer decode tasks we have scheduled, since each
@@ -351,8 +347,10 @@ class CONTENT_EXPORT V4L2VideoDecodeAccelerator
   int decoder_decode_buffer_tasks_scheduled_;
   // Picture buffers held by the client.
   int decoder_frames_at_client_;
-  // Are we flushing?
+  // Are we flushing? (miss-leading name to say we are draining)
   bool decoder_flushing_;
+  // Are we flushed ? (drained)
+  bool decoder_flushed_;
   // Got a notification from driver that it reached resolution change point
   // in the stream.
   bool resolution_change_pending_;

--- a/media/filters/gpu_video_decoder.cc
+++ b/media/filters/gpu_video_decoder.cc
@@ -279,14 +279,6 @@ void GpuVideoDecoder::RecordBufferData(const BitstreamBuffer& bitstream_buffer,
                                            buffer.timestamp(),
                                            config_.visible_rect(),
                                            config_.natural_size()));
-  // Why this value?  Because why not.  avformat.h:MAX_REORDER_DELAY is 16, but
-  // that's too small for some pathological B-frame test videos.  The cost of
-  // using too-high a value is low (192 bits per extra slot).
-  static const size_t kMaxInputBufferDataSize = 128;
-  // Pop from the back of the list, because that's the oldest and least likely
-  // to be useful in the future data.
-  if (input_buffer_data_.size() > kMaxInputBufferDataSize)
-    input_buffer_data_.pop_back();
 }
 
 void GpuVideoDecoder::GetBufferData(int32 id, base::TimeDelta* timestamp,
@@ -303,6 +295,38 @@ void GpuVideoDecoder::GetBufferData(int32 id, base::TimeDelta* timestamp,
     return;
   }
   NOTREACHED() << "Missing bitstreambuffer id: " << id;
+}
+
+void GpuVideoDecoder::RemoveBufferData(int32 id) {
+  base::TimeDelta timestamp;
+  bool found = false;
+
+  for (std::list<BufferData>::iterator it =
+           input_buffer_data_.begin(); it != input_buffer_data_.end();
+       ++it) {
+    if (it->bitstream_buffer_id != id)
+      continue;
+    DVLOG(3) << "Removing data for id: " << id;
+    timestamp = it->timestamp;
+    input_buffer_data_.erase(it);
+    break;
+  }
+
+  if (!found) {
+      NOTREACHED() << "Missing bitstreambuffer id: " << id;
+      return;
+  }
+
+  /* Remove anything older too to prevent the list from growing */
+  for (std::list<BufferData>::iterator it =
+           input_buffer_data_.begin(); it != input_buffer_data_.end();
+       ++it) {
+    if (it->timestamp < timestamp) {
+        DVLOG(3) << "Also removing data for id: " << it->bitstream_buffer_id;
+        input_buffer_data_.erase(it);
+    }
+    break;
+  }
 }
 
 bool GpuVideoDecoder::NeedsBitstreamConversion() const {
@@ -466,6 +490,7 @@ void GpuVideoDecoder::PictureReady(const media::Picture& picture) {
   DCHECK(inserted);
 
   DeliverFrame(frame);
+  RemoveBufferData(picture.bitstream_buffer_id());
 }
 
 void GpuVideoDecoder::DeliverFrame(

--- a/media/filters/gpu_video_decoder.h
+++ b/media/filters/gpu_video_decoder.h
@@ -112,6 +112,7 @@ class MEDIA_EXPORT GpuVideoDecoder
       const BitstreamBuffer& bitstream_buffer, const DecoderBuffer& buffer);
   void GetBufferData(int32 id, base::TimeDelta* timetamp,
                      gfx::Rect* visible_rect, gfx::Size* natural_size);
+  void RemoveBufferData(int32 id);
 
   void DestroyVDA();
 


### PR DESCRIPTION
These two patch enable draining in Chromium (will no longer block forever at the end) and fixes frame metadata tracking. The frame metadata was store in a fixed length fifo, and data would be lost for smaller resolution video as encoded frame are smaller and more can be stored in the driver fixed size ring buffer.