### PR TITLE
Remove StartupNotify=true from desktop file for now

### DIFF
--- a/debian/chromium-browser.desktop
+++ b/debian/chromium-browser.desktop
@@ -175,7 +175,6 @@ Icon=chromium-browser
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml_xml;x-scheme-handler/http;x-scheme-handler/https;
 StartupWMClass=Chromium-browser
-StartupNotify=true
 Actions=NewWindow;Incognito;TempProfile;
 X-AppInstall-Package=chromium-browser
 


### PR DESCRIPTION
This does not seem to be working correctly for Chromium - just remove it
for now.

[endlessm/eos-shell#5297]