### PR TITLE
debian/rules: use the right filename for the extra version libffmpegsumo.so

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 
 DEBIAN_NAME		:= $(shell dpkg-parsechangelog | sed -n 's/^Source: *\(.*\)$$/\1/ p')
 DEBIAN_VERSION		:= $(shell dpkg-parsechangelog | sed -n 's/^Version: *\(.*\)$$/\1/ p')
+DEBIAN_VERSION_BASE	:= $(shell echo $(DEBIAN_VERSION) | sed 's/^\(.*\)+[^-]*$$/\1/')
 DEBIAN_UPSTREAM_VERSION	:= $(shell echo $(DEBIAN_VERSION) | sed 's/^\(.*\)-[^-]*$$/\1/')
 DEBIAN_REVISION		:= $(shell echo $(DEBIAN_VERSION) | sed 's/^.*r\([^-]*\)-.*/\1/')
 DEBIAN_DIST		:= $(shell lsb_release -ds | tr -d '()' |sed -e 's/\#/ /g')
@@ -491,7 +492,7 @@ build-stamp-ffmpeg-%:
 	test "$${T}"; \
 	if [ "$${T}" == 'extra' ]; then \
 	  mkdir -p debian/tmp-$${T}/$(EXTRA_CODECS_DIR); \
-	  cp $(SRC_DIR)/out/$(BUILD_TYPE)/libffmpegsumo.so $(CURDIR)/debian/tmp-$*/$(EXTRA_CODECS_DIR)/libffmpegsumo.so.$(DEBIAN_UPSTREAM_VERSION); \
+	  cp $(SRC_DIR)/out/$(BUILD_TYPE)/libffmpegsumo.so $(CURDIR)/debian/tmp-$*/$(EXTRA_CODECS_DIR)/libffmpegsumo.so.$(DEBIAN_VERSION_BASE); \
 	else \
 	  mkdir -p debian/tmp-$${T}/$(LIB_DIR); \
 	  cp $(SRC_DIR)/out/$(BUILD_TYPE)/libffmpegsumo.so $(CURDIR)/debian/tmp-$*/$(LIB_DIR); \


### PR DESCRIPTION
Ignore the '+devXY.commitID' suffix from $(DEBIAN_VERSION) to rename
the extra version of libfmpegsumo.so by appending the browser version
number (e.g. 40.0.2214.111) only, so that chromium will find it when
looking for it under /var/lib/codecs.

[endlessm/eos-shell#5366]