### PR TITLE
debian/rules: adjust the regular expression for DEBIAN_VERSION_BASE

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 
 DEBIAN_NAME		:= $(shell dpkg-parsechangelog | sed -n 's/^Source: *\(.*\)$$/\1/ p')
 DEBIAN_VERSION		:= $(shell dpkg-parsechangelog | sed -n 's/^Version: *\(.*\)$$/\1/ p')
-DEBIAN_VERSION_BASE	:= $(shell echo $(DEBIAN_VERSION) | sed 's/^\(.*\)+[^-]*$$/\1/')
+DEBIAN_VERSION_BASE	:= $(shell echo $(DEBIAN_VERSION) | sed 's/^\([^-+]*\)[-+].*$$/\1/')
 DEBIAN_UPSTREAM_VERSION	:= $(shell echo $(DEBIAN_VERSION) | sed 's/^\(.*\)-[^-]*$$/\1/')
 DEBIAN_REVISION		:= $(shell echo $(DEBIAN_VERSION) | sed 's/^.*r\([^-]*\)-.*/\1/')
 DEBIAN_DIST		:= $(shell lsb_release -ds | tr -d '()' |sed -e 's/\#/ /g')


### PR DESCRIPTION
The previous rule was not working quite as well as expected with version
strings such as 40.0.2214.111+dev55.ce0035b-8bem1. This commit fixes that.

[endlessm/eos-shell#5366]