### PR TITLE
v4l2: create EGL image with true row stride

### DIFF
--- a/content/common/gpu/media/exynos_v4l2_video_device.cc
+++ b/content/common/gpu/media/exynos_v4l2_video_device.cc
@@ -141,6 +141,7 @@ EGLImageKHR ExynosV4L2Device::CreateEGLImage(EGLDisplay egl_display,
                                              EGLContext /* egl_context */,
                                              GLuint texture_id,
                                              gfx::Size frame_buffer_size,
+                                             int *plane_stride,
                                              unsigned int buffer_index,
                                              size_t planes_count) {
   DVLOG(3) << "CreateEGLImage()";
@@ -174,10 +175,10 @@ EGLImageKHR ExynosV4L2Device::CreateEGLImage(EGLDisplay egl_display,
   attrs[5] = DRM_FORMAT_NV12;
   attrs[7] = dmabuf_fds[0].get();
   attrs[9] = 0;
-  attrs[11] = frame_buffer_size.width();
+  attrs[11] = plane_stride[0];
   attrs[13] = dmabuf_fds[1].get();
   attrs[15] = 0;
-  attrs[17] = frame_buffer_size.width();
+  attrs[17] = plane_stride[1];
 
   EGLImageKHR egl_image = eglCreateImageKHR(
       egl_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attrs);

--- a/content/common/gpu/media/exynos_v4l2_video_device.h
+++ b/content/common/gpu/media/exynos_v4l2_video_device.h
@@ -33,6 +33,7 @@ class ExynosV4L2Device : public V4L2Device {
                                      EGLContext egl_context,
                                      GLuint texture_id,
                                      gfx::Size frame_buffer_size,
+                                     int *plane_stride,
                                      unsigned int buffer_index,
                                      size_t planes_count) override;
   virtual EGLBoolean DestroyEGLImage(EGLDisplay egl_display,

--- a/content/common/gpu/media/tegra_v4l2_video_device.cc
+++ b/content/common/gpu/media/tegra_v4l2_video_device.cc
@@ -174,6 +174,7 @@ EGLImageKHR TegraV4L2Device::CreateEGLImage(EGLDisplay egl_display,
                                             EGLContext egl_context,
                                             GLuint texture_id,
                                             gfx::Size /* frame_buffer_size */,
+                                            int * /* plane_stride */,
                                             unsigned int buffer_index,
                                             size_t /* planes_count */) {
   DVLOG(3) << "CreateEGLImage()";

--- a/content/common/gpu/media/tegra_v4l2_video_device.h
+++ b/content/common/gpu/media/tegra_v4l2_video_device.h
@@ -36,6 +36,7 @@ class TegraV4L2Device : public V4L2Device {
                                      EGLContext egl_context,
                                      GLuint texture_id,
                                      gfx::Size frame_buffer_size,
+                                     int *plane_stride,
                                      unsigned int buffer_index,
                                      size_t planes_count) override;
   virtual EGLBoolean DestroyEGLImage(EGLDisplay egl_display,

--- a/content/common/gpu/media/v4l2_video_decode_accelerator.cc
+++ b/content/common/gpu/media/v4l2_video_decode_accelerator.cc
@@ -183,6 +183,7 @@ V4L2VideoDecodeAccelerator::V4L2VideoDecodeAccelerator(
       output_planes_count_(0),
       picture_clearing_count_(0),
       pictures_assigned_(false, false),
+      plane_stride_(NULL),
       device_poll_thread_("V4L2DevicePollThread"),
       make_context_current_(make_context_current),
       egl_display_(egl_display),
@@ -203,6 +204,8 @@ V4L2VideoDecodeAccelerator::~V4L2VideoDecodeAccelerator() {
   // descriptors, mmap() segments, etc.
   DCHECK(input_buffer_map_.empty());
   DCHECK(output_buffer_map_.empty());
+
+  delete [] plane_stride_;
 }
 
 bool V4L2VideoDecodeAccelerator::Initialize(media::VideoCodecProfile profile,
@@ -361,6 +364,7 @@ void V4L2VideoDecodeAccelerator::AssignPictureBuffers(
                                                     egl_context_,
                                                     buffers[i].texture_id(),
                                                     frame_buffer_size_,
+                                                    plane_stride_,
                                                     i,
                                                     output_planes_count_);
     if (egl_image == EGL_NO_IMAGE_KHR) {
@@ -1626,6 +1630,10 @@ bool V4L2VideoDecodeAccelerator::CreateBuffersForFormat(
   output_planes_count_ = format.fmt.pix_mp.num_planes;
   frame_buffer_size_.SetSize(
       format.fmt.pix_mp.width, format.fmt.pix_mp.height);
+  delete [] plane_stride_;
+  plane_stride_ = new int[output_planes_count_];
+  for (size_t i = 0; i < output_planes_count_; i++)
+    plane_stride_[i] = format.fmt.pix_mp.plane_fmt[i].bytesperline;
   DVLOG(3) << "CreateBuffersForFormat(): new resolution: "
            << frame_buffer_size_.ToString();
 

--- a/content/common/gpu/media/v4l2_video_decode_accelerator.h
+++ b/content/common/gpu/media/v4l2_video_decode_accelerator.h
@@ -412,6 +412,9 @@ class CONTENT_EXPORT V4L2VideoDecodeAccelerator
   // Output picture size.
   gfx::Size frame_buffer_size_;
 
+  // Output buffer strides (per-plane)
+  int *plane_stride_;
+
   //
   // The device polling thread handles notifications of V4L2 device changes.
   //

--- a/content/common/gpu/media/v4l2_video_device.h
+++ b/content/common/gpu/media/v4l2_video_device.h
@@ -80,6 +80,7 @@ class V4L2Device {
                                      EGLContext egl_context,
                                      GLuint texture_id,
                                      gfx::Size frame_buffer_size,
+                                     int *plane_size,
                                      unsigned int buffer_index,
                                      size_t planes_count) = 0;
 


### PR DESCRIPTION
When creating EGL Images from video frames, Chromium was always using
the display width as the image buffer stride. That was resulting in
some videos being played back slanted (wrong stride), and other EGL
image imports being rejected by Mali due to not meeting basic alignment
requirements.

Take the stride info from V4L2 and use it in the EGLCreateImage call
to solve this.

[endlessm/eos-shell#5464]