### PR TITLE
Enable neon on ARM

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -114,7 +114,6 @@ GYP_DEFINES += clang=0
 ifeq (arm,$(DEB_HOST_ARCH_CPU))
 
 GYP_DEFINES += \
-	arm_neon=0 \
 	target_arch=arm \
 	use_cups=1 \
 	use_v4l2_codec=1 \
@@ -130,12 +129,9 @@ GYP_DEFINES += \
  endif
  ifeq (armhf,$(DEB_HOST_ARCH))
 GYP_PARAMS += -DUSE_EABI_HARDFLOAT 
-# ARN Neon optional flag is off because it causes build errors, AND testing
-# /proc/cpuinfo contents can't work with a sandbox anyway.
 GYP_DEFINES += \
-	arm_neon_optional=0 \
+	arm_neon=1 \
 	v8_use_arm_eabi_hardfloat=true \
-	arm_fpu=vfpv3-d16 \
 	arm_float_abi=hard \
 	arm_thumb=1 \
 	armv7=1 \


### PR DESCRIPTION
Testing EC-100, this results in a noticable improvement to webm
video playback.

[endlessm/eos-shell#5799]