### PR TITLE
Revert "Import patches/title-bar-default-system.patch-v35 from Ubuntu…

### DIFF
--- a/ui/base/x/x11_util.cc
+++ b/ui/base/x/x11_util.cc
@@ -1035,8 +1035,6 @@ void SetWindowRole(XDisplay* display, XID window, const std::string& role) {
 }
 
 bool GetCustomFramePrefDefault() {
-  return false;
-
   // If the window manager doesn't support enough of EWMH to tell us its name,
   // assume that it doesn't want custom frames. For example, _NET_WM_MOVERESIZE
   // is needed for frame-drag-initiated window movement.


### PR DESCRIPTION
… packaging"

This reverts commit b5654c83bb96ba87cb71d8cf32d139100b295de9.

When system title bars are used, Chromium renders onto one window pixmap,
and each frame is then then copied into a slightly larger one including
the window manager's window decorations.

When native title bars are used, Chromium renders directly into the
visible window pixmap. This provides a significant performance improvement
on ARM where the copy would otherwise be done with the CPU.

[endlessm/eos-shell#5184]