### PR TITLE
Do not show Chromium's default Welcome Page, not even on first run

### DIFF
--- a/chrome/browser/ui/startup/startup_browser_creator_impl.cc
+++ b/chrome/browser/ui/startup/startup_browser_creator_impl.cc
@@ -545,8 +545,9 @@ void StartupBrowserCreatorImpl::ProcessLaunchURLs(
     return;
   }
 
+  // Do NOT show the welcome page at any time on Endless.
   // Determine whether or not this launch must include the welcome page.
-  InitializeWelcomeRunType(urls_to_open);
+  // InitializeWelcomeRunType(urls_to_open);
 
 // TODO(tapted): Move this to startup_browser_creator_win.cc after refactor.
 #if defined(OS_WIN)


### PR DESCRIPTION
We recently stopped shipping the "First Run" sentinel file via
/etc/skel, meaning that now Chromium will always operate in "first run
mode" when launching the browser for the first time. This, among other
things (e.g. importing master preferences), means that the "Getting
Started" welcome page would be shown, which is not what we want.

Note that we could get a similar effect by simply passing --no-first-run
to chromium from the wrapper script (or redefining IsChromeFirstRun),
but doing that would also prevent other operations that we might find
interesting in the future, such as importing master preferences. Thus, a
more contained approach to fixing this problem is simply to never let
chromium initialize its "welcome run type" to anything other than NONE.

[endlessm/eos-shell#5865]