### PR TITLE
Do not include libwidevinecdm.so in the chromium-browser package.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -311,6 +311,10 @@ local-install-arch:
 	@set -eux
 	# Two stages: Install out of source tree. Copy to packaging.
 
+	# We don't want to ship the libwidevinecdm.so file, as it will be
+	# provided via our own downloader (eos-chrome-plugin-updater).
+	rm -f $(SRC_DIR)/out/$(BUILD_TYPE)-chromium/libwidevinecdm.so
+
 ifeq (1,$(COMPONENT_SHARED_LIB_BUILD))
 	mkdir -p                                                          $(CURDIR)/debian/tmp-std/$(LIB_DIR)/libs
 	mv -v $(SRC_DIR)/out/$(BUILD_TYPE)-chromium/lib/libffmpeg.so      $(CURDIR)/debian/tmp-std/$(LIB_DIR)/libs


### PR DESCRIPTION
We will resolve this dependency  via a plugin independently
downloaded and independently, under /var/lib.

[endlessm/eos-shell#3889]