### PR TITLE
 Force system's title bars on non-ARM platforms (e.g. Intel) by default

### DIFF
--- a/ui/base/x/x11_util.cc
+++ b/ui/base/x/x11_util.cc
@@ -1035,6 +1035,13 @@ void SetWindowRole(XDisplay* display, XID window, const std::string& role) {
 }
 
 bool GetCustomFramePrefDefault() {
+#if !defined(__ARMEL__)
+  // We don't force the system's title bars on ARM for performance reasons.
+  // On Intel this is a much less noticeable issue since the copy of data
+  // between chromium's own buffer and the visible one is accelerated by HW.
+  return false;
+#endif
+
   // If the window manager doesn't support enough of EWMH to tell us its name,
   // assume that it doesn't want custom frames. For example, _NET_WM_MOVERESIZE
   // is needed for frame-drag-initiated window movement.


### PR DESCRIPTION
For the sake of consistency with the rest of the desktop applications,
we need to bring back the system's title bar for chromium, since on
Intel there is no noticeable performance gain that justifies using
chromium's custom frame.

Note that the case of ARM is different, as the copy of data between
chromium's own buffer and the visible one is not accelerated by HW,
which is why we don't force system's title bars in that case.

[endlessm/eos-shell#5184]