### PR TITLE
Don't ever play the default "First Run experience"

### DIFF
--- a/chrome/browser/first_run/first_run.cc
+++ b/chrome/browser/first_run/first_run.cc
@@ -599,17 +599,11 @@ MasterPrefs::MasterPrefs()
 MasterPrefs::~MasterPrefs() {}
 
 bool IsChromeFirstRun() {
-  if (internal::g_first_run == internal::FIRST_RUN_UNKNOWN) {
-    internal::g_first_run = internal::FIRST_RUN_FALSE;
-    const base::CommandLine* command_line =
-        base::CommandLine::ForCurrentProcess();
-    if (command_line->HasSwitch(switches::kForceFirstRun) ||
-        (!command_line->HasSwitch(switches::kNoFirstRun) &&
-         !internal::IsFirstRunSentinelPresent())) {
-      internal::g_first_run = internal::FIRST_RUN_TRUE;
-    }
-  }
-  return internal::g_first_run == internal::FIRST_RUN_TRUE;
+  // We don't ever want a "First Run experience" to happen, so we
+  // just create the sentinel if needed and always return false.
+  if (!internal::IsFirstRunSentinelPresent())
+      internal::CreateSentinel();
+  return false;
 }
 
 #if defined(OS_MACOSX)

--- a/chrome/browser/ui/startup/startup_browser_creator_impl.cc
+++ b/chrome/browser/ui/startup/startup_browser_creator_impl.cc
@@ -545,9 +545,8 @@ void StartupBrowserCreatorImpl::ProcessLaunchURLs(
     return;
   }
 
-  // Do NOT show the welcome page at any time on Endless.
   // Determine whether or not this launch must include the welcome page.
-  // InitializeWelcomeRunType(urls_to_open);
+  InitializeWelcomeRunType(urls_to_open);
 
 // TODO(tapted): Move this to startup_browser_creator_win.cc after refactor.
 #if defined(OS_WIN)


### PR DESCRIPTION
We don't want to ever show the bubble overlay popping out of the address bar on the first run, nor the Getting Started webpage on a second tab.

Also, revert the change from endlessm/eos-shell#5865, since ignoring the First Run altogether is a superset of the solution implemented in there.

[endlessm/eos-shell#5937]