### PR TITLE
Force dependency on chromium-browser-l10n

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,8 +48,8 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
 	bash (>= 4),
 	libnss3,
 	xdg-utils,
-	chromium-codecs-ffmpeg (= ${binary:Version})
-Recommends: chromium-browser-l10n
+	chromium-codecs-ffmpeg (= ${binary:Version}),
+	chromium-browser-l10n
 Suggests: webaccounts-chromium-extension,
 	unity-chromium-extension,
 	adobe-flashplugin


### PR DESCRIPTION
In case anything is wrong with the localization,
we would rather fail the OSTree build rather
than silently omit translations.

[endlessm/eos-shell#5985-debian]