### PR TITLE
desktop_aura: Use a white pixel to fill the XWindow's background

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -1088,10 +1088,12 @@ void DesktopWindowTreeHostX11::OnCursorVisibilityChangedNative(bool show) {
 
 void DesktopWindowTreeHostX11::InitX11Window(
     const Widget::InitParams& params) {
-  unsigned long attribute_mask = CWBackPixmap;
+  unsigned long attribute_mask = CWBackPixel;
   XSetWindowAttributes swa;
   memset(&swa, 0, sizeof(swa));
-  swa.background_pixmap = None;
+
+  int whiteColor = WhitePixel(xdisplay_, DefaultScreen(xdisplay_));
+  swa.background_pixel = whiteColor;
 
   ::Atom window_type;
   switch (params.type) {


### PR DESCRIPTION
Instead of using nothing, which causes some weird effects when launching
chromium (e.g. XWindow initialized with data from the front buffer), while
the first expose event is not attended, define instead a solid colour
for the background so that at least the startup experience is consistent.

[endlessm/eos-shell#5873]