### PR TITLE
desktop_aura: Unset XWindow's background once it's mapped

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -1092,6 +1092,9 @@ void DesktopWindowTreeHostX11::InitX11Window(
   XSetWindowAttributes swa;
   memset(&swa, 0, sizeof(swa));
 
+  // Set the white color on startup to make the initial flickering
+  // happening between the XWindow is mapped and the first expose
+  // event is completely handled less annoying.
   int whiteColor = WhitePixel(xdisplay_, DefaultScreen(xdisplay_));
   swa.background_pixel = whiteColor;
 
@@ -1930,6 +1933,9 @@ uint32_t DesktopWindowTreeHostX11::DispatchEvent(
       FOR_EACH_OBSERVER(DesktopWindowTreeHostObserverX11,
                         observer_list_,
                         OnWindowMapped(xwindow_));
+      // Restore the XWindow's background after the window is shown for
+      // the first time, to avoid showing it all white while resizing.
+      XSetWindowBackgroundPixmap(xdisplay_, xwindow_, None);
       break;
     }
     case UnmapNotify: {


### PR DESCRIPTION
In commit 8d8fb734, we set the XWindow's background pixel to white to
make the flickering during startup less annoying, but that had the side
effect of making resizing quite disturbing, since the background is
quite visible while resizing, due to the slow rendering process.

This patch makes sure that the XWindow's background is unset (set to
None) once the window has been Mapped, thus making the resizing
experience as "good" as it used to be prior to that change.

[endlessm/eos-shell#5873]