### PR TITLE
Minimize number of render processes on 1GB systems

### DIFF
--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -444,6 +444,11 @@ size_t RenderProcessHost::GetMaxRendererProcessCount() {
 
   static size_t max_count = 0;
   if (!max_count) {
+    if (base::SysInfo::AmountOfPhysicalMemoryMB() <= 1024) {
+        max_count = 1;
+        return max_count;
+    }
+
     const size_t kEstimatedWebContentsMemoryUsage =
 #if defined(ARCH_CPU_64_BITS)
         60;  // In MB


### PR DESCRIPTION
On EC-100 with 1GB RAM, loading all the following sites at the same time
exhausts available memory, often before I've managed to start loading
them all:
 Exploration center, facebook, gmail, reuters,
 youtube(front page) and dailymotion(front page)

Reducing the number of render processes helps the situation here,
the system no longer becomes unusable under that workload. Reduce
it to the minimum, which results in Chromium only having 2 render
processes around.

[endlessm/eos-shell#6099]