### PR TITLE
Wait until the first SwapBuffers before resetting XWindow's background pixmap

### DIFF
--- a/ui/gl/gl_surface_egl.h
+++ b/ui/gl/gl_surface_egl.h
@@ -108,6 +108,10 @@ class GL_EXPORT NativeViewGLSurfaceEGL : public GLSurfaceEGL {
 
   int swap_interval_;
 
+  // FIXME: Part of temporary hack to restore the background pixel for the
+  // underlying XWindow. See NativeViewGLSurfaceGLX::SwapBuffers for details.
+  bool hasSwappedBuffers_;
+
 #if defined(OS_WIN)
   bool vsync_override_;
 

--- a/ui/gl/gl_surface_glx.cc
+++ b/ui/gl/gl_surface_glx.cc
@@ -460,7 +460,7 @@ void* GLSurfaceGLX::GetConfig(gfx::AcceleratedWidget window) {
 }
 
 NativeViewGLSurfaceGLX::NativeViewGLSurfaceGLX(gfx::AcceleratedWidget window)
-    : parent_window_(window), window_(0), config_(nullptr) {
+    : parent_window_(window), window_(0), config_(nullptr), hasSwappedBuffers_(false) {
 }
 
 gfx::AcceleratedWidget NativeViewGLSurfaceGLX::GetDrawableHandle() const {
@@ -550,6 +550,20 @@ gfx::SwapResult NativeViewGLSurfaceGLX::SwapBuffers() {
       "height", GetSize().height());
 
   glXSwapBuffers(g_display, GetDrawableHandle());
+
+  // FIXME: We need to restore the background pixel that we set to WhitePixel
+  // on views::DesktopWindowTreeHostX11::InitX11Window back to None for the XWindow
+  // associated to this surface after the first SwapBuffers has happened, to avoid
+  // showing a weird white background while resizing.
+  //
+  // This is probably not the right way to do it, so we try to do it only once for the
+  // lifetime of the surface, while we keep working on the proper solution upstream.
+  // https://code.google.com/p/chromium/issues/detail?id=554008
+  if (!hasSwappedBuffers_) {
+    XSetWindowBackgroundPixmap(g_display, parent_window_, 0);
+    hasSwappedBuffers_ = true;
+  }
+
   return gfx::SwapResult::SWAP_ACK;
 }
 

--- a/ui/gl/gl_surface_glx.h
+++ b/ui/gl/gl_surface_glx.h
@@ -91,6 +91,10 @@ class GL_EXPORT NativeViewGLSurfaceGLX : public GLSurfaceGLX,
 
   scoped_ptr<VSyncProvider> vsync_provider_;
 
+  // FIXME: Part of temporary hack to restore the background pixel for the
+  // underlying XWindow. See NativeViewGLSurfaceGLX::SwapBuffers for details.
+  bool hasSwappedBuffers_;
+
   DISALLOW_COPY_AND_ASSIGN(NativeViewGLSurfaceGLX);
 };
 

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -1935,9 +1935,6 @@ uint32_t DesktopWindowTreeHostX11::DispatchEvent(
       FOR_EACH_OBSERVER(DesktopWindowTreeHostObserverX11,
                         observer_list_,
                         OnWindowMapped(xwindow_));
-      // Restore the XWindow's background after the window is shown for
-      // the first time, to avoid showing it all white while resizing.
-      XSetWindowBackgroundPixmap(xdisplay_, xwindow_, None);
       break;
     }
     case UnmapNotify: {


### PR DESCRIPTION
This is a temporary solution while we work on fixing the issue upstream
in proper way, since the current experience on ARM is pretty bad, with
part of the screen being filled in white and the rest on black on startup.

See also: https://code.google.com/p/chromium/issues/detail?id=554008

[endlessm/eos-shell#6068]