### PR TITLE
Add a fast path for opening files when the browser is already running

### DIFF
--- a/debian/chromium-browser.sh.in
+++ b/debian/chromium-browser.sh.in
@@ -217,6 +217,19 @@ if [ $want_debug -eq 1 ] ; then
   fi
   exit $?
 else
+  # Try to poke an existing chromium process through the unix socket. If this
+  # succeeds and we get "ACK" back, exit this script. Otherwise keep going as
+  # normal.
+  hexargs=""
+  for arg in "START" "$(pwd)" $LIBDIR/$APPNAME $CHROMIUM_FLAGS "$@"
+  do
+    hexargs="$hexargs$(echo -ne "\0$arg" | xxd -p)"
+  done
+
+  if echo $hexargs | sed "s/^00//" | xxd -r -p | nc -U "$HOME/.config/chromium/SingletonSocket" 2> /dev/null | grep "^ACK$" > /dev/null; then
+    exit 0
+  fi
+
   if [ $want_temp_profile -eq 0 ] ; then
     exec $LIBDIR/$APPNAME $CHROMIUM_FLAGS "$@"
   else


### PR DESCRIPTION
Chromium normally initializes the whole main process when opening
a file, only to pass control to an already existing chromium
process if one exists. This is quite slow, especially on arm, where
it can take nearly 10 seconds. When possible, write the correct
args to the control socket from the launcher script instead.

[endlessm/eos-shell#6184]