### PR TITLE
Honour the value of the 'gtk-xft-dpi' GtkSetting property

### DIFF
--- a/build/linux/system.gyp
+++ b/build/linux/system.gyp
@@ -34,12 +34,7 @@
       'g_settings_get_boolean',
       'g_settings_get_int',
       'g_settings_get_strv',
-      'g_settings_new_full',
       'g_settings_list_schemas',
-      'g_settings_schema_source_get_default',
-      'g_settings_schema_source_lookup',
-      'g_settings_get',
-      'g_variant_lookup',
     ],
     'libpci_functions': [
       'pci_alloc',

--- a/ui/views/views.gyp
+++ b/ui/views/views.gyp
@@ -694,7 +694,6 @@
           'dependencies': [
             '../../build/linux/system.gyp:x11',
             '../../build/linux/system.gyp:xrandr',
-            '../../build/linux/system.gyp:gio',
             '../events/devices/events_devices.gyp:events_devices',
             '../events/platform/x11/x11_events_platform.gyp:x11_events_platform',
             '../gfx/x/gfx_x11.gyp:gfx_x11',

--- a/ui/views/widget/desktop_aura/desktop_screen_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_screen_x11.cc
@@ -315,7 +315,7 @@ std::vector<gfx::Display> DesktopScreenX11::BuildDisplaysFromXRandRInfo() {
 
   // As per-display scale factor is not supported right now,
   // the X11 root window's scale factor is always used.
-  float device_scale_factor = GetDeviceScaleFactor();
+  const float device_scale_factor = GetDeviceScaleFactor();
   for (int i = 0; i < resources->noutput; ++i) {
     RROutput output_id = resources->outputs[i];
     gfx::XScopedPtr<XRROutputInfo,
@@ -342,13 +342,11 @@ std::vector<gfx::Display> DesktopScreenX11::BuildDisplaysFromXRandRInfo() {
       gfx::Display display(display_id, crtc_bounds);
 
       // An integer that forces discrete steps.
-      int density_indicator = 8;
+      int density_indicator = 0;
 #ifdef USE_GLIB
       if (display_scales != NULL) {
-        if (! g_variant_lookup(display_scales, output_info->name, "i",
-                                &density_indicator)) {
-          density_indicator = 8;  // default scale is 1
-        }
+        (void) g_variant_lookup(display_scales, output_info->name, "i",
+                                &density_indicator);
         DCHECK_LE(0, density_indicator);
         DVLOG(1) << "Got density indictor " << density_indicator << " from display_scales for " << output_info->name;
       }

--- a/ui/views/widget/desktop_aura/desktop_screen_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_screen_x11.cc
@@ -7,12 +7,7 @@
 #include <X11/extensions/Xrandr.h>
 #include <X11/Xlib.h>
 
-#ifdef USE_GLIB
-#include <gio/gio.h>
-#include <glib.h>
-#endif
-
-// It clashes with our RootWindow.
+// It clashes with out RootWindow.
 #undef RootWindow
 
 #include "base/logging.h"
@@ -281,29 +276,6 @@ std::vector<gfx::Display> DesktopScreenX11::BuildDisplaysFromXRandRInfo() {
     return GetFallbackDisplayList();
   }
 
-#ifdef USE_GLIB
-  GSettingsSchemaSource* gsettings_schema_source =
-      g_settings_schema_source_get_default();
-  GSettingsSchema* gsettings_schema =
-      g_settings_schema_source_lookup(gsettings_schema_source,
-                                      "com.ubuntu.user-interface", TRUE);
-
-  GVariant* display_scales = NULL;
-  if (gsettings_schema != NULL) {
-    GSettings* gsettings = NULL;
-    gsettings = g_settings_new_full(gsettings_schema, NULL, NULL);
-
-    if (gsettings != NULL) {
-      g_settings_get(gsettings, "scale-factor", "@a{si}", &display_scales);
-      DVLOG(1) << "Got com.ubuntu.desktop gsettings.";
-    } else {
-      DVLOG(1) << "No com.ubuntu.desktop gsettings available.";
-    }
-  } else {
-    DVLOG(1) << "No com.ubuntu.desktop gsettings schema available.";
-  }
-#endif
-
   bool has_work_area = false;
   gfx::Rect work_area_in_pixels;
   std::vector<int> value;
@@ -341,27 +313,7 @@ std::vector<gfx::Display> DesktopScreenX11::BuildDisplaysFromXRandRInfo() {
       gfx::Rect crtc_bounds(crtc->x, crtc->y, crtc->width, crtc->height);
       gfx::Display display(display_id, crtc_bounds);
 
-      // An integer that forces discrete steps.
-      int density_indicator = 0;
-#ifdef USE_GLIB
-      if (display_scales != NULL) {
-        (void) g_variant_lookup(display_scales, output_info->name, "i",
-                                &density_indicator);
-        DCHECK_LE(0, density_indicator);
-        DVLOG(1) << "Got density indictor " << density_indicator << " from display_scales for " << output_info->name;
-      }
-#else
-      VLOG(1) << "Not using gsettings to get display scale info. No use_glib";
-#endif
-
-      if (density_indicator != 0) {
-        // n/8 is actual scaling factor.  Zero means discover from hardware.
-        device_scale_factor = float(density_indicator / 8.0);
-        DVLOG(1) << "Set " << output_info->name << " screen scaling to "
-                 << device_scale_factor << " from gsettings.";
-        display.SetScaleAndBounds(device_scale_factor, crtc_bounds);
-      } else if (!gfx::Display::HasForceDeviceScaleFactor()) {
-        DVLOG(1) << "Didn't use gsettings info at all.  Picked " << device_scale_factor;
+      if (!gfx::Display::HasForceDeviceScaleFactor()) {
         display.SetScaleAndBounds(device_scale_factor, crtc_bounds);
       }
 


### PR DESCRIPTION
We were not properly reading this value because of a patch we inherited from Ubuntu, which was overriding it (chromium was reading it already) even after not being able to read a GSetting key from a Ubuntu-specific GSetting schema that we don't use.

Thus, reverting these changes gets our chromium reading and using the actual DPI value again.

[endlessm/eos-shell#6074]