### PR TITLE
Always use navigation buttons from the classic theme

### DIFF
--- a/chrome/browser/themes/theme_service.cc
+++ b/chrome/browser/themes/theme_service.cc
@@ -24,6 +24,7 @@
 #include "chrome/browser/themes/theme_syncable_service.h"
 #include "chrome/common/chrome_constants.h"
 #include "chrome/common/pref_names.h"
+#include "components/grit/components_scaled_resources.h"
 #include "content/public/browser/notification_service.h"
 #include "content/public/browser/user_metrics.h"
 #include "extensions/browser/extension_prefs.h"
@@ -100,6 +101,41 @@ bool IsColorGrayscale(SkColor color) {
   int b = SkColorGetB(color);
   int range = std::max(r, std::max(g, b)) - std::min(r, std::min(g, b));
   return range < kChannelTolerance;
+}
+
+bool IsThemeableImage(int id) {
+  // We don't want to theme some icons when using the GTK+ theme, since
+  // they look worse than the default ones, and quite bad when scaled up.
+  switch (id) {
+  case IDR_OMNIBOX_CALCULATOR:
+  case IDR_OMNIBOX_EXTENSION_APP:
+  case IDR_OMNIBOX_HTTP:
+  case IDR_OMNIBOX_SEARCH:
+  case IDR_OMNIBOX_STAR:
+  case IDR_OMNIBOX_TTS:
+  case IDR_OMNIBOX_EXTENSION_APP_DARK:
+  case IDR_OMNIBOX_HTTP_DARK:
+  case IDR_OMNIBOX_SEARCH_DARK:
+  case IDR_OMNIBOX_STAR_DARK:
+  case IDR_OMNIBOX_TTS_DARK:
+  case IDR_BACK:
+  case IDR_BACK_D:
+  case IDR_FORWARD:
+  case IDR_FORWARD_D:
+  case IDR_HOME:
+  case IDR_RELOAD:
+  case IDR_RELOAD_D:
+  case IDR_STOP:
+  case IDR_STOP_D:
+    return false;
+
+  default:
+    // See Gtk2UI::GenerateGtkThemeBitmap() in gtk2_ui.cc to get
+    // an idea of which types of images would be in this case.
+    return true;
+  }
+
+  return true;
 }
 
 }  // namespace
@@ -184,9 +220,8 @@ void ThemeService::Init(Profile* profile) {
 
 gfx::Image ThemeService::GetImageNamed(int id) const {
   DCHECK(CalledOnValidThread());
-
   gfx::Image image;
-  if (theme_supplier_.get())
+  if (IsThemeableImage(id) && theme_supplier_.get())
     image = theme_supplier_->GetImageNamed(id);
 
   if (image.IsEmpty())

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
@@ -1073,23 +1073,6 @@ GdkColor Gtk2UI::BuildAndSetFrameColor(const GdkColor* base,
 }
 
 SkBitmap Gtk2UI::GenerateGtkThemeBitmap(int id) const {
-  // Consider Right-To-Left text direction for arrow buttons.
-  if (base::i18n::IsRTL()) {
-    switch (id) {
-    case IDR_BACK:
-      return GenerateGTKIcon(IDR_FORWARD);
-    case IDR_BACK_D:
-      return GenerateGTKIcon(IDR_FORWARD_D);
-    case IDR_FORWARD:
-      return GenerateGTKIcon(IDR_BACK);
-    case IDR_FORWARD_D:
-      return GenerateGTKIcon(IDR_BACK_D);
-
-    default:
-      break;
-    }
-  }
-
   switch (id) {
     case IDR_THEME_TOOLBAR: {
       GtkStyle* style = gtk_rc_get_style(fake_window_);


### PR DESCRIPTION
The icons picked from the current GTK+ theme are not looking good when using a higher value for text-scaling-factor (higher DPI), and in general they look worse than the ones from the classich chromium theme, at least for the current GTK+ theme we are shipping, so we want to change that,

So, we blacklist certain images from being themed by GTK+ (navigation buttons, search "magnifier" icon, lock icon...), so that we make sure those will be picked from the classic theme instead, which won't try to copy a bitmap and then scale it up, as the current machinery in gtk2_ui.cc does.

Also, we get rid of the hack to fix navigation icons from the GTK+ theme for RTL languages, as that's not an issue when using chromium's icons from its classic theme.

[endlessm/eos-shell#5869]