### PR TITLE
Consider com.endlessm.CompositeMode.text-scaling-factor GSetting if available

### DIFF
--- a/build/linux/system.gyp
+++ b/build/linux/system.gyp
@@ -29,12 +29,16 @@
     ],
     'libgio_functions': [
       'g_settings_new',
+      'g_settings_new_full',
       'g_settings_get_child',
       'g_settings_get_string',
       'g_settings_get_boolean',
+      'g_settings_get_double',
       'g_settings_get_int',
       'g_settings_get_strv',
       'g_settings_list_schemas',
+      'g_settings_schema_source_get_default',
+      'g_settings_schema_source_lookup',
     ],
     'libpci_functions': [
       'pci_alloc',

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
@@ -1441,7 +1441,7 @@ float Gtk2UI::GetDeviceScaleFactor() const {
   // Round to 1 decimal, e.g. to 1.4.
   const float rounded = roundf(scale * 10) / 10;
   // See crbug.com/484400
-  return rounded < 1.3 ? 1.0 : rounded;
+  return rounded < 1.3f ? 1.0f : rounded;
 }
 
 }  // namespace libgtk2ui

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <set>
 
+#include <gio/gio.h>
 #include <pango/pango.h>
 
 #include "base/command_line.h"
@@ -176,6 +177,10 @@ const int kAutocompleteImages[] = {
   IDR_OMNIBOX_TTS,
   IDR_OMNIBOX_TTS_DARK,
 };
+
+// GSettings schema and key for the additional scaling factor defined by Endless.
+const char* kEndlessCompositeModeSchema = "com.endlessm.CompositeMode";
+const char* kEndlessCompositeModeScalingFactorKey = "browser-scaling-factor";
 
 // This table converts button ids into a pair of gtk-stock id and state.
 struct IDRGtkMapping {
@@ -424,7 +429,9 @@ Gtk2UI::Gtk2UI()
     : default_font_size_pixels_(0),
       default_font_style_(gfx::Font::NORMAL),
       middle_click_action_(GetDefaultMiddleClickAction()),
-      device_scale_factor_(1.0) {
+      device_scale_factor_(1.0),
+      endless_gsettings_(NULL)
+{
   GtkInitFromCommandLine(*base::CommandLine::ForCurrentProcess());
 }
 
@@ -460,6 +467,16 @@ void Gtk2UI::Initialize() {
 
   indicators_count = 0;
 
+  /* The com.endlessm.CompositeMode schema will be present in some configurations only,
+   * so we need to do some extra checks here before assuming it's there. */
+  GSettingsSchema* schema = g_settings_schema_source_lookup(g_settings_schema_source_get_default(), kEndlessCompositeModeSchema, FALSE);
+  if (schema != NULL) {
+    endless_gsettings_ = g_settings_new_full(schema, NULL, NULL);
+    DVLOG(1) << "Found " << kEndlessCompositeModeSchema << " GSettings schema.";
+  } else {
+    DVLOG(1) << "No " << kEndlessCompositeModeSchema << " GSettings schema found.";
+  }
+
   // Instantiate the singleton instance of Gtk2EventLoop.
   Gtk2EventLoop::GetInstance();
 }
@@ -471,6 +488,8 @@ Gtk2UI::~Gtk2UI() {
   fake_entry_.Destroy();
 
   ClearAllThemeData();
+
+  g_clear_object(&endless_gsettings_);
 }
 
 gfx::Image Gtk2UI::GetThemeImageNamed(int id) const {
@@ -1421,6 +1440,30 @@ void Gtk2UI::UpdateDefaultFont(const PangoFontDescription* desc) {
   default_font_style_ = query.style;
 }
 
+float Gtk2UI::GetEndlessScalingFactor() const {
+  static float cached_result = -1.0f;
+
+  // The GSettings instance will be null in those configurations where
+  // we are not using eos-composite-mode, so we need to check this first;
+  if (!endless_gsettings_) {
+    return 1.0f;
+  }
+
+  // We only check the scaling factor on start up, not to confuse the UI in
+  // case the value of the GSettings key changes while chromium is running.
+  if (cached_result < 0.0f) {
+    double browser_scaling_factor = g_settings_get_double(endless_gsettings_, kEndlessCompositeModeScalingFactorKey);
+    DVLOG(1) << "GSetting browser-scaling-factor key found: " << browser_scaling_factor;
+
+    // The browse-scaling-factor should already be in [1.0, 2.0], but it
+    // does we'd better do some extra validation here, before applying it.
+    cached_result = std::max(1.0, std::min(browser_scaling_factor, 2.0));
+  }
+
+  DVLOG(1) << "Effective scaling-factor to be applied for Endless: " << cached_result;
+  return cached_result;
+}
+
 void Gtk2UI::OnStyleSet(GtkWidget* widget, GtkStyle* previous_style) {
   ClearAllThemeData();
   LoadGtkValues();
@@ -1438,8 +1481,12 @@ float Gtk2UI::GetDeviceScaleFactor() const {
     return gfx::Display::GetForcedDeviceScaleFactor();
   const int kCSSDefaultDPI = 96;
   const float scale = GetDPI() / kCSSDefaultDPI;
+
+  // Endless can define an additional scaling factor to consider when on Composite
+  // mode that the browser will apply on top of whatever the current DPI value is.
+  float endless_factor = GetEndlessScalingFactor();
   // Round to 1 decimal, e.g. to 1.4.
-  const float rounded = roundf(scale * 10) / 10;
+  const float rounded = roundf(endless_factor * scale * 10) / 10;
   // See crbug.com/484400
   return rounded < 1.3f ? 1.0f : rounded;
 }

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.cc
@@ -1437,9 +1437,11 @@ float Gtk2UI::GetDeviceScaleFactor() const {
   if (gfx::Display::HasForceDeviceScaleFactor())
     return gfx::Display::GetForcedDeviceScaleFactor();
   const int kCSSDefaultDPI = 96;
-  float scale = GetDPI() / kCSSDefaultDPI;
+  const float scale = GetDPI() / kCSSDefaultDPI;
   // Round to 1 decimal, e.g. to 1.4.
-  return roundf(scale * 10) / 10;
+  const float rounded = roundf(scale * 10) / 10;
+  // See crbug.com/484400
+  return rounded < 1.3 ? 1.0 : rounded;
 }
 
 }  // namespace libgtk2ui

--- a/chrome/browser/ui/libgtk2ui/gtk2_ui.h
+++ b/chrome/browser/ui/libgtk2ui/gtk2_ui.h
@@ -8,6 +8,8 @@
 #include <map>
 #include <vector>
 
+#include <gio/gio.h>
+
 #include "base/basictypes.h"
 #include "base/compiler_specific.h"
 #include "base/memory/scoped_ptr.h"
@@ -202,6 +204,9 @@ class Gtk2UI : public views::LinuxUI {
   // Updates |default_font_*| based on |desc|.
   void UpdateDefaultFont(const PangoFontDescription* desc);
 
+  // Gets the additional scaling factor that might have been defined on Endless.
+  float GetEndlessScalingFactor() const;
+
   // Handles signal from GTK that our theme has been changed.
   CHROMEGTK_CALLBACK_1(Gtk2UI, void, OnStyleSet, GtkStyle*);
 
@@ -269,6 +274,10 @@ class Gtk2UI : public views::LinuxUI {
   NativeThemeGetter native_theme_overrider_;
 
   float device_scale_factor_;
+
+  // Only used in certain configurations of Endless devices, where we
+  // want to define an additional scaling factor when on composite mode.
+  GSettings* endless_gsettings_;
 
   DISALLOW_COPY_AND_ASSIGN(Gtk2UI);
 };

--- a/ui/views/views.gyp
+++ b/ui/views/views.gyp
@@ -694,6 +694,7 @@
           'dependencies': [
             '../../build/linux/system.gyp:x11',
             '../../build/linux/system.gyp:xrandr',
+            '../../build/linux/system.gyp:gio',
             '../events/devices/events_devices.gyp:events_devices',
             '../events/platform/x11/x11_events_platform.gyp:x11_events_platform',
             '../gfx/x/gfx_x11.gyp:gfx_x11',


### PR DESCRIPTION
If the eos-composite-mode package is installed, the com.endlessm.CompositeMode
will be available to provide an additional, accumulative, scaling factor to be
used on top of the one from org.gnome.desktop.interface, so we need to check
it here to determine the right value to set for the global Xft DPI setting.

Contrary to what gnome-settings-daemon does (check the 'text-scaling-factor'
key from the schema), chromium checks the 'browser-scaling-factor' key instead,
which is defined by eos-composite-mode to be specifically used by the browser
only, so that we can define an additional scaling factor just for it.

[endlessm/eos-shell#6197]