### PR TITLE
Fix lack of sound for HTML5 audio elements on Duolingo 

### DIFF
--- a/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
+++ b/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
@@ -598,8 +598,16 @@ void HTMLMediaElement::removedFrom(ContainerNode* insertionPoint)
     HTMLElement::removedFrom(insertionPoint);
     if (insertionPoint->inActiveDocument()) {
         configureMediaControls();
-        if (m_networkState > NETWORK_EMPTY)
-            pause();
+        if (m_networkState > NETWORK_EMPTY) {
+            // We stop <video> elements when removing them from their containers instead of pausing
+            // them to avoid keeping the video decoder element alive for too long, as that could
+            // result in some sites falling back to SW decoding in case it's not possible to create
+            // a HW decoding element while the old one is still in use (e.g. V4L2). See shell#6246.
+            if (isHTMLVideoElement())
+                stop();
+            else
+                pause();
+        }
     }
 }
 

--- a/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
+++ b/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
@@ -595,13 +595,11 @@ void HTMLMediaElement::removedFrom(ContainerNode* insertionPoint)
 {
     WTF_LOG(Media, "HTMLMediaElement::removedFrom(%p, %p)", this, insertionPoint);
 
-    userCancelledLoad();
-
     HTMLElement::removedFrom(insertionPoint);
     if (insertionPoint->inActiveDocument()) {
         configureMediaControls();
-        //if (m_networkState > NETWORK_EMPTY)
-        //    pause();
+        if (m_networkState > NETWORK_EMPTY)
+            pause();
     }
 }
 
@@ -1926,11 +1924,6 @@ void HTMLMediaElement::play()
         m_userGestureRequiredForPlay = false;
     }
 
-    /* Ignore request if the element isn't in the active page to minimize
-     * hardware decoder resource usage */
-    if (!inActiveDocument())
-        return;
-
     playInternal();
 }
 
@@ -1998,11 +1991,6 @@ void HTMLMediaElement::gesturelessInitialPlayHalted()
 void HTMLMediaElement::pause()
 {
     WTF_LOG(Media, "HTMLMediaElement::pause(%p)", this);
-
-    /* Ignore request if the element isn't in the active page to minimize
-     * hardware decoder resource usage */
-    if (!inActiveDocument())
-        return;
 
     if (!m_player || m_networkState == NETWORK_EMPTY)
         scheduleDelayedAction(LoadMediaResource);


### PR DESCRIPTION
This reverts the original commit for #2310 and re-writes it so that it does not break sites playing <audio> from outside the currently active document, like Duolingo, while keeping the issue with Vimeo.com and the V4L2 video decoder fixed (no fallback to SW decoding when navigating videos).

[endlessm/eos-shell#6246]