### PR TITLE
Don't create toolbar actions for our Endless extensions

### DIFF
--- a/chrome/common/extensions/manifest_handlers/extension_action_handler.cc
+++ b/chrome/common/extensions/manifest_handlers/extension_action_handler.cc
@@ -63,6 +63,9 @@ bool ExtensionActionHandler::Parse(Extension* extension,
       return true;  // Do nothing if the switch is off.
     if (Manifest::IsComponentLocation(extension->location()))
       return true;  // Don't synthesize actions for component extensions.
+    if (extension->is_endless_os())
+      return true; // Don't synthesize actions for our Exploration Center extension.
+
     if (extension->manifest()->HasKey(
             manifest_keys::kSynthesizeExtensionAction)) {
       *error = base::ASCIIToUTF16(base::StringPrintf(

--- a/extensions/common/extension.cc
+++ b/extensions/common/extension.cc
@@ -439,6 +439,13 @@ bool Extension::is_theme() const {
   return manifest()->is_theme();
 }
 
+bool Extension::is_endless_os() const {
+  if (manifest_->extension_id() == "fpmnjlkappdkncfmjefheaidpmbmfdfk")
+    return true; // EOS Exploration Center.
+
+  return false;
+}
+
 void Extension::AddWebExtentPattern(const URLPattern& pattern) {
   // Bookmark apps are permissionless.
   if (from_bookmark())

--- a/extensions/common/extension.h
+++ b/extensions/common/extension.h
@@ -362,6 +362,7 @@ class Extension : public base::RefCountedThreadSafe<Extension> {
   bool is_extension() const;
   bool is_shared_module() const;
   bool is_theme() const;
+  bool is_endless_os() const;
 
   void AddWebExtentPattern(const URLPattern& pattern);
   const URLPatternSet& web_extent() const { return extent_; }


### PR DESCRIPTION
This prevents the icon from our own extensions (e.g. Exploration
Center) from showing up in the toolbar on Chromium 48+, as that's
now enforced for every extension, even if don't have an icon.

[endlessm/eos-shell#6349]