### PR TITLE
Implement a MemoryPressureMonitor for Endless

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1351,6 +1351,7 @@ test("base_unittests") {
     "memory/discardable_shared_memory_unittest.cc",
     "memory/linked_ptr_unittest.cc",
     "memory/memory_pressure_monitor_chromeos_unittest.cc",
+    "memory/memory_pressure_monitor_endless_unittest.cc",
     "memory/memory_pressure_monitor_win_unittest.cc",
     "memory/ref_counted_memory_unittest.cc",
     "memory/ref_counted_unittest.cc",

--- a/base/base.gyp
+++ b/base/base.gyp
@@ -524,6 +524,7 @@
         'memory/linked_ptr_unittest.cc',
         'memory/memory_pressure_listener_unittest.cc',
         'memory/memory_pressure_monitor_chromeos_unittest.cc',
+        'memory/memory_pressure_monitor_endless_unittest.cc',
         'memory/memory_pressure_monitor_mac_unittest.cc',
         'memory/memory_pressure_monitor_win_unittest.cc',
         'memory/ref_counted_memory_unittest.cc',

--- a/base/base.gypi
+++ b/base/base.gypi
@@ -346,6 +346,8 @@
           'memory/memory_pressure_monitor.h',
           'memory/memory_pressure_monitor_chromeos.cc',
           'memory/memory_pressure_monitor_chromeos.h',
+          'memory/memory_pressure_monitor_endless.cc',
+          'memory/memory_pressure_monitor_endless.h',
           'memory/memory_pressure_monitor_mac.cc',
           'memory/memory_pressure_monitor_mac.h',
           'memory/memory_pressure_monitor_win.cc',

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -94,4 +94,12 @@ const char kEnableCrashReporterForTesting[] =
     "enable-crash-reporter-for-testing";
 #endif
 
+#if defined(OS_LINUX)
+// Used to override the default thresholds used by the MemoryPressureMonitor
+// to notify the MemoryPressureListener that a relevant event has occurred.
+// If defined they must be integers between [0, 100], with CRITICAL > MODERATE.
+const char kMemoryPressureModerateThreshold[] = "memory-pressure-moderate-threshold";
+const char kMemoryPressureCriticalThreshold[] = "memory-pressure-critical-threshold";
+#endif
+
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -37,6 +37,11 @@ extern const char kDisableUsbKeyboardDetect[];
 extern const char kEnableCrashReporterForTesting[];
 #endif
 
+#if defined(OS_LINUX)
+extern const char kMemoryPressureModerateThreshold[];
+extern const char kMemoryPressureCriticalThreshold[];
+#endif
+
 }  // namespace switches
 
 #endif  // BASE_BASE_SWITCHES_H_

--- a/base/memory/BUILD.gn
+++ b/base/memory/BUILD.gn
@@ -20,6 +20,8 @@ source_set("memory") {
     "memory_pressure_monitor.h",
     "memory_pressure_monitor_chromeos.cc",
     "memory_pressure_monitor_chromeos.h",
+    "memory_pressure_monitor_endless.cc",
+    "memory_pressure_monitor_endless.h",
     "memory_pressure_monitor_mac.cc",
     "memory_pressure_monitor_mac.h",
     "memory_pressure_monitor_win.cc",

--- a/base/memory/memory_pressure_monitor_endless.cc
+++ b/base/memory/memory_pressure_monitor_endless.cc
@@ -1,0 +1,141 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/memory/memory_pressure_monitor_endless.h"
+
+#include "base/process/process_metrics.h"
+#include "base/single_thread_task_runner.h"
+#include "base/sys_info.h"
+#include "base/thread_task_runner_handle.h"
+#include "base/time/time.h"
+
+namespace base {
+
+namespace endless {
+
+// The time between memory pressure checks. While under critical pressure, this
+// is also the timer to repeat cleanup attempts.
+const int kMemoryPressureIntervalMs = 1000;
+
+// The time which should pass between two moderate memory pressure calls.
+const int kModerateMemoryPressureCooldownMs = 10000;
+
+// Number of event polls before the next moderate pressure event can be sent.
+const int kModerateMemoryPressureCooldown = kModerateMemoryPressureCooldownMs / kMemoryPressureIntervalMs;
+
+// Default threshold (as in % of used memory) for emission of memory pressure events.
+const int kDefaultMemoryPressureModerateThreshold = 45;
+const int kDefaultMemoryPressureCriticalThreshold = 80;
+
+MemoryPressureMonitor::MemoryPressureMonitor()
+    : current_memory_pressure_level_(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE)
+    , moderate_pressure_repeat_count_(0)
+    , weak_ptr_factory_(this) {
+
+	StartObserving();
+}
+
+MemoryPressureMonitor::~MemoryPressureMonitor() {
+  StopObserving();
+}
+
+MemoryPressureListener::MemoryPressureLevel MemoryPressureMonitor::GetCurrentPressureLevel() const {
+  return current_memory_pressure_level_;
+}
+
+// static
+MemoryPressureMonitor* MemoryPressureMonitor::Get() {
+  return static_cast<MemoryPressureMonitor*>(
+      base::MemoryPressureMonitor::Get());
+}
+
+void MemoryPressureMonitor::StartObserving() {
+  timer_.Start(FROM_HERE,
+               TimeDelta::FromMilliseconds(kMemoryPressureIntervalMs),
+               Bind(&MemoryPressureMonitor::CheckMemoryPressure,
+                    weak_ptr_factory_.GetWeakPtr()));
+}
+
+void MemoryPressureMonitor::StopObserving() {
+  // If StartObserving failed, StopObserving will still get called.
+  timer_.Stop();
+}
+
+void MemoryPressureMonitor::CheckMemoryPressure() {
+  MemoryPressureListener::MemoryPressureLevel old_pressure = current_memory_pressure_level_;
+
+  current_memory_pressure_level_ = GetMemoryPressureLevelFromPercent(GetUsedMemoryInPercent());
+
+  // In case there is no memory pressure we do not notify.
+  if (current_memory_pressure_level_ == MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE) {
+    return;
+  }
+
+  if (old_pressure == current_memory_pressure_level_) {
+    // If the memory pressure is still at the same level, we notify again for a
+    // critical level. In case of a moderate level repeat however, we only send
+    // a notification after a certain time has passed.
+    if (current_memory_pressure_level_ == MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE
+        && ++moderate_pressure_repeat_count_ < kModerateMemoryPressureCooldown) {
+      return;
+    }
+  } else if (current_memory_pressure_level_ == MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE &&
+             old_pressure == MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL) {
+    // When we reducing the pressure level from critical to moderate, we
+    // restart the timeout and do not send another notification.
+    moderate_pressure_repeat_count_ = 0;
+    return;
+  }
+  moderate_pressure_repeat_count_ = 0;
+  MemoryPressureListener::NotifyMemoryPressure(current_memory_pressure_level_);
+}
+
+// Converts free percent of memory into a memory pressure value.
+MemoryPressureListener::MemoryPressureLevel MemoryPressureMonitor::GetMemoryPressureLevelFromPercent(int percent) {
+  if (percent < kDefaultMemoryPressureModerateThreshold)
+    return MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE;
+
+  if (percent < kDefaultMemoryPressureCriticalThreshold)
+    return MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE;
+
+  return MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL;
+}
+
+// Gets the used memory in percent.
+int MemoryPressureMonitor::GetUsedMemoryInPercent() {
+  base::SystemMemoryInfoKB info;
+  if (!base::GetSystemMemoryInfo(&info)) {
+    VLOG(1) << "Cannot determine the free memory of the system.";
+    return 0;
+  }
+
+  // The available memory consists of "real" and virtual (z)ram memory.
+  // Since swappable memory uses a non pre-deterministic compression and
+  // the compression creates its own "dynamic" in the system, it gets
+  // de-emphasized by the |kSwapWeight| factor.
+  const int kSwapWeight = 4;
+
+  // The total memory we have is the "real memory" plus the virtual (z)ram.
+  int total_memory = info.total + info.swap_total / kSwapWeight;
+
+  // The kernel internally uses 50MB.
+  const int kMinFileMemory = 50 * 1024;
+
+  // Most file memory can be easily reclaimed.
+  int file_memory = info.active_file + info.inactive_file;
+  // unless it is dirty or it's a minimal portion which is required.
+  file_memory -= info.dirty + kMinFileMemory;
+
+  // Available memory is the sum of free, swap and easy reclaimable memory.
+  int available_memory =
+      info.free + info.swap_free / kSwapWeight + file_memory;
+
+  DCHECK(available_memory < total_memory);
+  int percentage = ((total_memory - available_memory) * 100) / total_memory;
+  return percentage;
+}
+
+} // namespace endless
+
+}  // namespace base

--- a/base/memory/memory_pressure_monitor_endless.cc
+++ b/base/memory/memory_pressure_monitor_endless.cc
@@ -4,8 +4,11 @@
 
 #include "base/memory/memory_pressure_monitor_endless.h"
 
+#include "base/base_switches.h"
+#include "base/command_line.h"
 #include "base/process/process_metrics.h"
 #include "base/single_thread_task_runner.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/sys_info.h"
 #include "base/thread_task_runner_handle.h"
 #include "base/time/time.h"
@@ -31,8 +34,11 @@ const int kDefaultMemoryPressureCriticalThreshold = 80;
 MemoryPressureMonitor::MemoryPressureMonitor()
     : current_memory_pressure_level_(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE)
     , moderate_pressure_repeat_count_(0)
+    , moderate_threshold_(kDefaultMemoryPressureModerateThreshold)
+    , critical_threshold_(kDefaultMemoryPressureCriticalThreshold)
     , weak_ptr_factory_(this) {
 
+	ParseCommandLineParameters();
 	StartObserving();
 }
 
@@ -48,6 +54,30 @@ MemoryPressureListener::MemoryPressureLevel MemoryPressureMonitor::GetCurrentPre
 MemoryPressureMonitor* MemoryPressureMonitor::Get() {
   return static_cast<MemoryPressureMonitor*>(
       base::MemoryPressureMonitor::Get());
+}
+
+void MemoryPressureMonitor::ParseCommandLineParameters() {
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  std::string switch_str;
+  int value;
+
+  // Parse the switch for the MODERATE threshold (should be a positive integer between 0 - 100).
+  if (command_line->HasSwitch(switches::kMemoryPressureModerateThreshold)) {
+    switch_str = command_line->GetSwitchValueASCII(switches::kMemoryPressureModerateThreshold);
+    if (base::StringToInt(switch_str, &value) && value >= 0 && value < 100)
+      moderate_threshold_ = value;
+    else
+      VLOG(1) << "Invalid switch for memory-pressure-moderate-threshold: " << switch_str;
+  }
+
+  // Parse the switch for the CRITICAL threshold (should be a positive integer between MODERATE - 100).
+  if (command_line->HasSwitch(switches::kMemoryPressureCriticalThreshold)) {
+    switch_str = command_line->GetSwitchValueASCII(switches::kMemoryPressureCriticalThreshold);
+    if (base::StringToInt(switch_str, &value) && value > moderate_threshold_ && value < 100)
+      critical_threshold_ = value;
+    else
+      VLOG(1) << "Invalid switch for memory-pressure-critical-threshold: " << switch_str;
+  }
 }
 
 void MemoryPressureMonitor::StartObserving() {
@@ -93,10 +123,10 @@ void MemoryPressureMonitor::CheckMemoryPressure() {
 
 // Converts free percent of memory into a memory pressure value.
 MemoryPressureListener::MemoryPressureLevel MemoryPressureMonitor::GetMemoryPressureLevelFromPercent(int percent) {
-  if (percent < kDefaultMemoryPressureModerateThreshold)
+  if (percent < moderate_threshold_)
     return MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE;
 
-  if (percent < kDefaultMemoryPressureCriticalThreshold)
+  if (percent < critical_threshold_)
     return MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE;
 
   return MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL;

--- a/base/memory/memory_pressure_monitor_endless.h
+++ b/base/memory/memory_pressure_monitor_endless.h
@@ -16,6 +16,9 @@ namespace base {
 
 namespace endless {
 
+class TestMemoryPressureMonitor;
+
+
 class BASE_EXPORT MemoryPressureMonitor : public base::MemoryPressureMonitor {
  public:
   explicit MemoryPressureMonitor();
@@ -29,6 +32,8 @@ class BASE_EXPORT MemoryPressureMonitor : public base::MemoryPressureMonitor {
   static MemoryPressureMonitor* Get();
 
  private:
+  friend TestMemoryPressureMonitor;
+
   // Starts observing the memory fill level.
   // Calls to StartObserving should always be matched with calls to
   // StopObserving.
@@ -50,8 +55,8 @@ class BASE_EXPORT MemoryPressureMonitor : public base::MemoryPressureMonitor {
   // Returns the correct MemoryPressureLevel according to the moderate and critical tresholds.
   MemoryPressureListener::MemoryPressureLevel GetMemoryPressureLevelFromPercent(int percent);
 
-  // Get the memory pressure in percent.
-  int GetUsedMemoryInPercent();
+  // Get the memory pressure in percent (virtual for testing).
+  virtual int GetUsedMemoryInPercent();
 
   // The current memory pressure.
   base::MemoryPressureListener::MemoryPressureLevel current_memory_pressure_level_;

--- a/base/memory/memory_pressure_monitor_endless.h
+++ b/base/memory/memory_pressure_monitor_endless.h
@@ -1,0 +1,76 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_MEMORY_MEMORY_PRESSURE_MONITOR_ENDLESS_H_
+#define BASE_MEMORY_MEMORY_PRESSURE_MONITOR_ENDLESS_H_
+
+#include "base/base_export.h"
+#include "base/macros.h"
+#include "base/memory/memory_pressure_listener.h"
+#include "base/memory/memory_pressure_monitor.h"
+#include "base/memory/weak_ptr.h"
+#include "base/timer/timer.h"
+
+namespace base {
+
+namespace endless {
+
+class BASE_EXPORT MemoryPressureMonitor : public base::MemoryPressureMonitor {
+ public:
+  explicit MemoryPressureMonitor();
+  ~MemoryPressureMonitor() override;
+
+  // Get the current memory pressure level.
+  MemoryPressureListener::MemoryPressureLevel GetCurrentPressureLevel() const override;
+
+  // Returns a type-casted version of the current memory pressure monitor. A
+  // simple wrapper to base::MemoryPressureMonitor::Get.
+  static MemoryPressureMonitor* Get();
+
+ private:
+  // Starts observing the memory fill level.
+  // Calls to StartObserving should always be matched with calls to
+  // StopObserving.
+  void StartObserving();
+
+  // Stop observing the memory fill level.
+  // May be safely called if StartObserving has not been called.
+  void StopObserving();
+
+  // The function which gets periodically called to check any changes in the
+  // memory pressure. It will report pressure changes as well as continuous
+  // critical pressure levels.
+  void CheckMemoryPressure();
+
+  // The function periodically checks the memory pressure changes and records
+  // the UMA histogram statistics for the current memory pressure level.
+  void CheckMemoryPressureAndRecordStatistics();
+
+  // Returns the correct MemoryPressureLevel according to the moderate and critical tresholds.
+  MemoryPressureListener::MemoryPressureLevel GetMemoryPressureLevelFromPercent(int percent);
+
+  // Get the memory pressure in percent.
+  int GetUsedMemoryInPercent();
+
+  // The current memory pressure.
+  base::MemoryPressureListener::MemoryPressureLevel current_memory_pressure_level_;
+
+  // A periodic timer to check for resource pressure changes. This will get
+  // replaced by a kernel triggered event system (see crbug.com/381196).
+  base::RepeatingTimer timer_;
+
+  // To slow down the amount of moderate pressure event calls, this counter
+  // gets used to count the number of events since the last event occured.
+  int moderate_pressure_repeat_count_;
+
+  base::WeakPtrFactory<MemoryPressureMonitor> weak_ptr_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(MemoryPressureMonitor);
+};
+
+} // namespace endless
+
+}  // namespace base
+
+#endif  // BASE_MEMORY_MEMORY_PRESSURE_MONITOR_ENDLESS_H_

--- a/base/memory/memory_pressure_monitor_endless.h
+++ b/base/memory/memory_pressure_monitor_endless.h
@@ -34,6 +34,9 @@ class BASE_EXPORT MemoryPressureMonitor : public base::MemoryPressureMonitor {
  private:
   friend TestMemoryPressureMonitor;
 
+  // Parses the command line parameters in case we want to define our own thresholds;
+  void ParseCommandLineParameters();
+
   // Starts observing the memory fill level.
   // Calls to StartObserving should always be matched with calls to
   // StopObserving.
@@ -68,6 +71,10 @@ class BASE_EXPORT MemoryPressureMonitor : public base::MemoryPressureMonitor {
   // To slow down the amount of moderate pressure event calls, this counter
   // gets used to count the number of events since the last event occured.
   int moderate_pressure_repeat_count_;
+
+  // Thresholds (as in % of used memory) to decide when to emit memory pressure events.
+  int moderate_threshold_;
+  int critical_threshold_;
 
   base::WeakPtrFactory<MemoryPressureMonitor> weak_ptr_factory_;
 

--- a/base/memory/memory_pressure_monitor_endless_unittest.cc
+++ b/base/memory/memory_pressure_monitor_endless_unittest.cc
@@ -1,0 +1,161 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/memory/memory_pressure_monitor_endless.h"
+
+#include "base/basictypes.h"
+#include "base/memory/memory_pressure_listener.h"
+#include "base/message_loop/message_loop.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace base {
+
+namespace endless {
+
+namespace {
+
+// True if the memory notifier got called. Do not read/modify value directly.
+bool on_memory_pressure_called = false;
+
+// If the memory notifier got called, this is the memory pressure reported.
+MemoryPressureListener::MemoryPressureLevel on_memory_pressure_level =
+    MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE;
+
+// Processes OnMemoryPressure calls.
+void OnMemoryPressure(MemoryPressureListener::MemoryPressureLevel level) {
+  on_memory_pressure_called = true;
+  on_memory_pressure_level = level;
+}
+
+// Resets the indicator for memory pressure.
+void ResetOnMemoryPressureCalled() {
+  on_memory_pressure_called = false;
+}
+
+// Returns true when OnMemoryPressure was called (and resets it).
+bool WasOnMemoryPressureCalled() {
+  bool b = on_memory_pressure_called;
+  ResetOnMemoryPressureCalled();
+  return b;
+}
+
+}  // namespace
+
+class TestMemoryPressureMonitor : public MemoryPressureMonitor {
+ public:
+  TestMemoryPressureMonitor()
+      : MemoryPressureMonitor()
+      , memory_in_percent_override_(0) {
+    // Disable any timers which are going on and set a special memory reporting function.
+    StopObserving();
+  }
+  ~TestMemoryPressureMonitor() override {}
+
+  void SetMemoryInPercentOverride(int percent) {
+    memory_in_percent_override_ = percent;
+  }
+
+  void CheckMemoryPressureForTest() {
+    CheckMemoryPressure();
+  }
+
+ private:
+  int GetUsedMemoryInPercent() override {
+    return memory_in_percent_override_;
+  }
+
+  int memory_in_percent_override_;
+  DISALLOW_COPY_AND_ASSIGN(TestMemoryPressureMonitor);
+};
+
+// This test tests the various transition states from memory pressure, looking
+// for the correct behavior on event reposting as well as state updates.
+TEST(EndlessMemoryPressureMonitorTest, CheckMemoryPressure) {
+  base::MessageLoopForUI message_loop;
+  scoped_ptr<TestMemoryPressureMonitor> monitor(new TestMemoryPressureMonitor);
+  scoped_ptr<MemoryPressureListener> listener(new MemoryPressureListener(base::Bind(&OnMemoryPressure)));
+
+  // Checking the memory pressure while 0% are used should not produce any events.
+  monitor->SetMemoryInPercentOverride(0);
+  ResetOnMemoryPressureCalled();
+
+  monitor->CheckMemoryPressureForTest();
+  message_loop.RunUntilIdle();
+  EXPECT_FALSE(WasOnMemoryPressureCalled());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE, monitor->GetCurrentPressureLevel());
+
+  // Setting the memory level to 44% should not produce produce any event.
+  monitor->SetMemoryInPercentOverride(44);
+  monitor->CheckMemoryPressureForTest();
+  message_loop.RunUntilIdle();
+  EXPECT_FALSE(WasOnMemoryPressureCalled());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE, monitor->GetCurrentPressureLevel());
+
+  // Setting the memory level to 45% should produce a moderate pressure level.
+  monitor->SetMemoryInPercentOverride(45);
+  monitor->CheckMemoryPressureForTest();
+  message_loop.RunUntilIdle();
+  EXPECT_TRUE(WasOnMemoryPressureCalled());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, monitor->GetCurrentPressureLevel());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, on_memory_pressure_level);
+
+  // We need to check that the event gets reposted after a while.
+  int i = 0;
+  for (; i < 100; i++) {
+    // Check the upper boundary for the MODERATE LEVEL.
+    monitor->SetMemoryInPercentOverride(79);
+    monitor->CheckMemoryPressureForTest();
+    message_loop.RunUntilIdle();
+    EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, monitor->GetCurrentPressureLevel());
+    if (WasOnMemoryPressureCalled()) {
+      EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, on_memory_pressure_level);
+      break;
+    }
+  }
+  // Should be more then 5 and less then 100.
+  EXPECT_LE(5, i);
+  EXPECT_GE(99, i);
+
+  // Setting the memory usage to 80% should produce critical levels.
+  monitor->SetMemoryInPercentOverride(80);
+  monitor->CheckMemoryPressureForTest();
+  message_loop.RunUntilIdle();
+  EXPECT_TRUE(WasOnMemoryPressureCalled());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL, on_memory_pressure_level);
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL, monitor->GetCurrentPressureLevel());
+
+  // Getting a consecutive critical event should immediately produce a second call.
+  monitor->SetMemoryInPercentOverride(99);
+  monitor->CheckMemoryPressureForTest();
+  message_loop.RunUntilIdle();
+  EXPECT_TRUE(WasOnMemoryPressureCalled());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL, on_memory_pressure_level);
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL, monitor->GetCurrentPressureLevel());
+
+  // When lowering the pressure again we should not get an event, but the pressure should go back to moderate.
+  monitor->SetMemoryInPercentOverride(50);
+  monitor->CheckMemoryPressureForTest();
+  message_loop.RunUntilIdle();
+  EXPECT_FALSE(WasOnMemoryPressureCalled());
+  EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, monitor->GetCurrentPressureLevel());
+
+  // We should need exactly the same amount of calls as before, before the next
+  // call comes in.
+  int j = 0;
+  for (; j < 100; j++) {
+    monitor->CheckMemoryPressureForTest();
+    message_loop.RunUntilIdle();
+    EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, monitor->GetCurrentPressureLevel());
+    if (WasOnMemoryPressureCalled()) {
+      EXPECT_EQ(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE, on_memory_pressure_level);
+      break;
+    }
+  }
+  // We should have needed exactly the same amount of checks as before.
+  EXPECT_EQ(j, i);
+}
+
+}  // namespace endless
+
+}  // namespace base

--- a/chrome/app/generated_resources.grd
+++ b/chrome/app/generated_resources.grd
@@ -15293,7 +15293,7 @@ Please check your email at <ph name="ACCOUNT_EMAIL">$2<ex>jane.doe@gmail.com</ex
         Saved passwords for <ph name="ORIGIN">$1<ex>example.com</ex></ph>:
       </message>
 
-    <if expr="is_win or is_macosx">
+    <if expr="is_win or is_macosx or is_linux">
       <!-- Tab discarding -->
       <message name="IDS_FLAGS_ENABLE_TAB_DISCARDING_NAME" desc="Name for the flag to enable tab discarding.">
         Enable tab discarding
@@ -15301,7 +15301,7 @@ Please check your email at <ph name="ACCOUNT_EMAIL">$2<ex>jane.doe@gmail.com</ex
       <message name="IDS_FLAGS_ENABLE_TAB_DISCARDING_DESCRIPTION" desc="Description for the flag to enable tab description.">
         If enabled, tabs get discarded from memory when the system memory is low. Discarded tabs are still visible on the tab strip and get reloaded when clicked on.
       </message>
-    </if>
+   </if>
 
     <if expr="is_android">
       <message name="IDS_FLAGS_OFFLINE_PAGES_NAME" desc="Name for the flag to enable offline pages.">

--- a/chrome/browser/about_flags.cc
+++ b/chrome/browser/about_flags.cc
@@ -2120,11 +2120,11 @@ const FeatureEntry kFeatureEntries[] = {
      SINGLE_VALUE_TYPE_AND_VALUE(switches::kDisableAutoHidingToolbarThreshold,
                                  "800")},
 #endif
-#if defined(OS_WIN) || defined(OS_MACOSX)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
     {"automatic-tab-discarding", IDS_FLAGS_ENABLE_TAB_DISCARDING_NAME,
-     IDS_FLAGS_ENABLE_TAB_DISCARDING_DESCRIPTION, kOsWin | kOsMac,
+     IDS_FLAGS_ENABLE_TAB_DISCARDING_DESCRIPTION, kOsAll,
      FEATURE_VALUE_TYPE(features::kAutomaticTabDiscarding)},
-#endif  // OS_WIN || OS_MACOSX
+#endif  // OS_WIN || OS_MACOSX || defined(OS_LINUX)
     // NOTE: Adding new command-line switches requires adding corresponding
     // entries to enum "LoginCustomFlags" in histograms.xml. See note in
     // histograms.xml and don't forget to run AboutFlagsHistogramTest unit test.

--- a/chrome/browser/browser_process_impl.cc
+++ b/chrome/browser/browser_process_impl.cc
@@ -149,7 +149,7 @@
 #include "chrome/browser/media/webrtc_log_uploader.h"
 #endif
 
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
 #include "chrome/browser/memory/tab_manager.h"
 #endif
 
@@ -786,7 +786,7 @@ gcm::GCMDriver* BrowserProcessImpl::gcm_driver() {
 
 memory::TabManager* BrowserProcessImpl::GetTabManager() {
   DCHECK(CalledOnValidThread());
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
   if (!tab_manager_.get())
     tab_manager_.reset(new memory::TabManager());
   return tab_manager_.get();

--- a/chrome/browser/browser_process_impl.h
+++ b/chrome/browser/browser_process_impl.h
@@ -323,7 +323,7 @@ class BrowserProcessImpl : public BrowserProcess,
   scoped_ptr<ChromeDeviceClient> device_client_;
 #endif
 
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
   // Any change to this #ifdef must be reflected as well in
   // chrome/browser/memory/tab_manager_browsertest.cc
   scoped_ptr<memory::TabManager> tab_manager_;

--- a/chrome/browser/chrome_browser_main.cc
+++ b/chrome/browser/chrome_browser_main.cc
@@ -1165,7 +1165,7 @@ void ChromeBrowserMainParts::PreBrowserStart() {
 #elif defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
   if (base::FeatureList::IsEnabled(features::kAutomaticTabDiscarding)) {
     // The default behavior is to only discard once (for now).
-    g_browser_process->GetTabManager()->Start(true);
+    g_browser_process->GetTabManager()->Start(false);
   }
 #endif
 }

--- a/chrome/browser/chrome_browser_main.cc
+++ b/chrome/browser/chrome_browser_main.cc
@@ -1162,7 +1162,7 @@ void ChromeBrowserMainParts::PreBrowserStart() {
 // now.
 #if defined(OS_CHROMEOS)
   g_browser_process->GetTabManager()->Start(false);
-#elif defined(OS_WIN) || defined(OS_MACOSX)
+#elif defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
   if (base::FeatureList::IsEnabled(features::kAutomaticTabDiscarding)) {
     // The default behavior is to only discard once (for now).
     g_browser_process->GetTabManager()->Start(true);

--- a/chrome/browser/memory/tab_manager_browsertest.cc
+++ b/chrome/browser/memory/tab_manager_browsertest.cc
@@ -24,7 +24,7 @@
 
 using content::OpenURLParams;
 
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
 
 namespace memory {
 
@@ -279,4 +279,4 @@ IN_PROC_BROWSER_TEST_F(TabManagerTest, ProtectPDFPages) {
 
 }  // namespace memory
 
-#endif  // OS_WIN || OS_CHROMEOS
+#endif  // OS_WIN || OS_MACOSX || OS_CHROMEOS || OS_LINUX

--- a/chrome/browser/ui/webui/about_ui.cc
+++ b/chrome/browser/ui/webui/about_ui.cc
@@ -459,7 +459,7 @@ std::string ChromeURLs() {
   return html;
 }
 
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
 
 const char kAboutDiscardsRunCommand[] = "run";
 
@@ -617,7 +617,7 @@ std::string AboutDiscards(const std::string& path) {
   return output;
 }
 
-#endif  // OS_WIN || OS_CHROMEOS
+#endif  // OS_WIN || OS_MACOSX || OS_CHROMEOS || OS_LINUX
 
 // AboutDnsHandler bounces the request back to the IO thread to collect
 // the DNS information.
@@ -949,7 +949,7 @@ void AboutUIHTMLSource::StartDataRequest(
 
     response = ResourceBundle::GetSharedInstance().GetRawDataResource(
         idr).as_string();
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
   } else if (source_name_ == chrome::kChromeUIDiscardsHost) {
     response = AboutDiscards(path);
 #endif

--- a/chrome/browser/ui/webui/about_ui.cc
+++ b/chrome/browser/ui/webui/about_ui.cc
@@ -581,13 +581,29 @@ std::string AboutDiscards(const std::string& path) {
 
   base::SystemMemoryInfoKB meminfo;
   base::GetSystemMemoryInfo(&meminfo);
+
   output.append("<h3>System memory information in MB</h3>");
   output.append("<table>");
   // Start with summary statistics.
-  output.append(AddStringRow(
-      "Total", base::IntToString(meminfo.total / 1024)));
-  output.append(AddStringRow(
-      "Free", base::IntToString(meminfo.free / 1024)));
+  output.append(AddStringRow("Total", base::IntToString(meminfo.total / 1024)));
+  output.append(AddStringRow("Free RAM", base::IntToString(meminfo.free / 1024)));
+  output.append(AddStringRow("Swap Total", base::IntToString(meminfo.swap_total / 1024)));
+  output.append(AddStringRow("Swap Free", base::IntToString(meminfo.swap_free / 1024)));
+  output.append(AddStringRow("Cached", base::IntToString(meminfo.cached / 1024)));
+  output.append(AddStringRow("Buffers", base::IntToString(meminfo.buffers / 1024)));
+  output.append(AddStringRow("Cached+Buffers", base::IntToString((meminfo.cached + meminfo.buffers) / 1024)));
+  output.append(AddStringRow("Active Files", base::IntToString(meminfo.active_file / 1024)));
+  output.append(AddStringRow("Inactive Files", base::IntToString(meminfo.inactive_file / 1024)));
+  output.append(AddStringRow("Dirty", base::IntToString(meminfo.dirty / 1024)));
+
+  // Check base::endless::MemoryPressureMonitor::GetUsedMemoryInPercent to know where these values come from.
+  const int kSwapWeight = 4, kMinFileMemory = 50 * 1024;
+  int total_memory = meminfo.total + meminfo.swap_total / kSwapWeight;
+  int file_memory = meminfo.active_file + meminfo.inactive_file - meminfo.dirty - kMinFileMemory;
+  int available_memory = meminfo.free + meminfo.swap_free / kSwapWeight + file_memory;
+  int percentage = ((total_memory - available_memory) * 100) / total_memory;
+  output.append(AddStringRow("Memory in use (%)", base::IntToString(percentage)));
+
 #if defined(OS_CHROMEOS)
   int mem_allocated_kb = meminfo.active_anon + meminfo.inactive_anon;
 #if defined(ARCH_CPU_ARM_FAMILY)

--- a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
+++ b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
@@ -291,7 +291,7 @@ bool IsAboutUI(const GURL& url) {
 #if defined(OS_CHROMEOS)
           || url.host() == chrome::kChromeUIOSCreditsHost
 #endif
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
           || url.host() == chrome::kChromeUIDiscardsHost
 #endif
           );  // NOLINT

--- a/chrome/common/chrome_features.cc
+++ b/chrome/common/chrome_features.cc
@@ -11,7 +11,7 @@ namespace features {
 #if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
 // Enables automatic tab discarding, when the system is in low memory state.
 const base::Feature kAutomaticTabDiscarding{"AutomaticTabDiscarding",
-                                            base::FEATURE_DISABLED_BY_DEFAULT};
+                                            base::FEATURE_ENABLED_BY_DEFAULT};
 #endif  // defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
 
 }  // namespace features

--- a/chrome/common/chrome_features.cc
+++ b/chrome/common/chrome_features.cc
@@ -8,10 +8,10 @@ namespace features {
 
 // All features in alphabetical order.
 
-#if defined(OS_WIN) || defined(OS_MACOSX)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
 // Enables automatic tab discarding, when the system is in low memory state.
 const base::Feature kAutomaticTabDiscarding{"AutomaticTabDiscarding",
                                             base::FEATURE_DISABLED_BY_DEFAULT};
-#endif  // defined(OS_WIN) || defined(OS_MACOSX)
+#endif  // defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
 
 }  // namespace features

--- a/chrome/common/chrome_features.h
+++ b/chrome/common/chrome_features.h
@@ -15,9 +15,9 @@ namespace features {
 // All features in alphabetical order. The features should be documented
 // alongside the definition of their values in the .cc file.
 
-#if defined(OS_WIN) || defined(OS_MACOSX)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
 extern const base::Feature kAutomaticTabDiscarding;
-#endif  // defined(OS_WIN) || defined(OS_MACOSX)
+#endif  // defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_LINUX)
 
 // DON'T ADD RANDOM STUFF HERE. Put it in the main section above in
 // alphabetical order, or in one of the ifdefs (also in order in each section).

--- a/chrome/common/url_constants.cc
+++ b/chrome/common/url_constants.cc
@@ -147,7 +147,7 @@ const char kChromeUIWebRtcLogsURL[] = "chrome://webrtc-logs/";
 const char kChromeUIMediaRouterURL[] = "chrome://media-router/";
 #endif
 
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
 const char kChromeUIDiscardsHost[] = "discards";
 const char kChromeUIDiscardsURL[] = "chrome://discards/";
 #endif
@@ -673,7 +673,7 @@ const char* const kChromeHostURLs[] = {
   kChromeUIProxySettingsHost,
   kChromeUIVoiceSearchHost,
 #endif
-#if defined(OS_WIN) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_CHROMEOS) || defined(OS_LINUX)
   kChromeUIDiscardsHost,
 #endif
 #if defined(OS_POSIX) && !defined(OS_MACOSX) && !defined(OS_ANDROID)

--- a/chrome/common/url_constants.h
+++ b/chrome/common/url_constants.h
@@ -140,7 +140,7 @@ extern const char kChromeUIWebRtcLogsURL[];
 extern const char kChromeUIMediaRouterURL[];
 #endif
 
-#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS)
+#if defined(OS_WIN) || defined(OS_MACOSX) || defined(OS_CHROMEOS) || defined(OS_LINUX)
 extern const char kChromeUIDiscardsHost[];
 extern const char kChromeUIDiscardsURL[];
 #endif

--- a/content/browser/browser_main_loop.cc
+++ b/content/browser/browser_main_loop.cc
@@ -137,6 +137,10 @@
 #include "chromeos/chromeos_switches.h"
 #endif
 
+#if defined(OS_LINUX)
+#include "base/memory/memory_pressure_monitor_endless.h"
+#endif
+
 #if defined(USE_GLIB)
 #include <glib-object.h>
 #endif
@@ -728,6 +732,8 @@ int BrowserMainLoop::PreCreateThreads() {
 #elif defined(OS_WIN)
   memory_pressure_monitor_.reset(CreateWinMemoryPressureMonitor(
       parsed_command_line_));
+#elif defined(OS_LINUX)
+  memory_pressure_monitor_.reset(new base::endless::MemoryPressureMonitor());
 #endif
 
 #if defined(ENABLE_PLUGINS)


### PR DESCRIPTION
This branch is based in the implementation for ChromeOS present in Chromium 48, with some tweaks to adapt it to our needs (e.g. we don't need the metrics stuff), so that we can enable the "Automatic Tabs Discards" feature in our platform.

It also adds two command line flags to allow overriding the default thresholds.

[endlessm/eos-shell#1331]