### PR TITLE
Revert "Add video mime/types to desktop file for ARM"

### DIFF
--- a/debian/chromium-browser.desktop
+++ b/debian/chromium-browser.desktop
@@ -173,7 +173,7 @@ X-MultipleArgs=false
 Type=Application
 Icon=chromium-browser
 Categories=Network;WebBrowser;
-MimeType=text/html;text/xml;application/xhtml_xml;x-scheme-handler/http;x-scheme-handler/https;video/mp4;video/mp4v-es;video/ogg;video/webm;video/x-m4v;video/x-ogm+ogg;video/x-theora;
+MimeType=text/html;text/xml;application/xhtml_xml;x-scheme-handler/http;x-scheme-handler/https;
 Actions=NewWindow;Incognito;TempProfile;
 X-AppInstall-Package=chromium-browser
 


### PR DESCRIPTION
We no longer open local files in the browser by default,
so there is no reason to carry around the patch to the
mime types in the desktop file.

This reverts commit 8a586352db6bf2001085dad8dfeaad06c06307ff.

Conflicts:
	debian/chromium-browser.desktop

[endlessm/eos-shell#6057]