### PR TITLE
Consider the provisional document loader when overriding the User Agent

### DIFF
--- a/third_party/WebKit/Source/core/loader/FrameLoader.cpp
+++ b/third_party/WebKit/Source/core/loader/FrameLoader.cpp
@@ -1214,12 +1214,14 @@ void FrameLoader::restoreScrollPositionAndViewState()
 
 String FrameLoader::userAgent() const
 {
-    Document* document = m_frame->document();
     String clientUserAgent = client()->userAgent();
 
     // On Endless, we need to still be able to alter the UserAgent string depending
-    // on the URL we are loading, so we adapt it if needed before applying it.
-    String userAgent = document ? adaptUserAgentForURL(clientUserAgent, document->url()) : clientUserAgent;
+    // on the URL we are loading, so we adapt it if needed before applying it. But we
+    // might not have a committed load, so we first check the URL from the provisional
+    // loader before trying with the regular one, so that we always get a valid URL.
+    const DocumentLoader& activeLoader = m_provisionalDocumentLoader.get() ? *m_provisionalDocumentLoader : *m_documentLoader;
+    String userAgent = adaptUserAgentForURL(clientUserAgent, activeLoader.request().url());
 
     InspectorInstrumentation::applyUserAgentOverride(m_frame, &userAgent);
     return userAgent;


### PR DESCRIPTION
In some cases (e.g. calendar.google.com), waiting for the document loader
to reach the "committed" state to decide whether to override the User Agent
string might be too late, as a redirection to a new URL address might have
already happened making the override useless in the end.

To workaround this problem, we don't assume that the document has a valid
URL at the time we decide whether to override the UA. Instead, we check
the URL from the original request from either the provisional document
loader (if it exists) or from the regular one, in that precise order.

https://phabricator.endlessm.com/T6093