### PR TITLE
Update network state if no data has been processed when removing media elements

### DIFF
--- a/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
+++ b/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
@@ -558,6 +558,13 @@ void HTMLMediaElement::removedFrom(ContainerNode* insertionPoint)
 {
     WTF_LOG(Media, "HTMLMediaElement::removedFrom(%p, %p)", this, insertionPoint);
 
+    // Update the current network state based on whether we have processed data or not at
+    // this point, so that we don't mistakenly call pause() or stop() below if not needed.
+    if (m_readyState == HAVE_NOTHING) {
+        setNetworkState(NETWORK_EMPTY);
+        scheduleEvent(EventTypeNames::emptied);
+    }
+
     HTMLElement::removedFrom(insertionPoint);
     if (insertionPoint->inActiveDocument()) {
         configureMediaControls();


### PR DESCRIPTION
In some cases media elements will get removedFrom() called early when loading
the document for the first time and no data has actually been processed, even
if the network state is no longer EMPTY, causing the current logic to end up
calling stop() or pause() when it shouldn't.

This causes a specific problem with Video.JS powered sites, in which videos
will either fail to start after clicking on the play button or get hidden
behind the poster image (when using one), so we'd better make sure the network
state is set to EMPTY if no data has been received when calling removedFrom().

https://phabricator.endlessm.com/T6293