### PR TITLE
Revert to gcc/g++ over clang

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Build-Depends:
 	python,
 	bison,
 	gperf,
-	clang (>= 3.5),
 	libpulse-dev,
 	libcups2-dev | libcupsys2-dev,
 	libasound2-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -109,8 +109,8 @@ GYP_DEFINES += enable_hangout_services_extension=1
 GYP_DEFINES += enable_widevine=1 enable_pepper_cdms=1
 
 # Prefer gcc/g++ over clang until clang is better tested in Ubuntu.
-GYP_DEFINES += clang=1
-GYP_DEFINES += clang_use_chrome_plugins=0
+GYP_DEFINES += clang=0
+#GYP_DEFINES += clang_use_chrome_plugins=0
 
 #GYP_DEFINES += use_ozone=1 ozone_auto_platforms=0 ozone_platform_mir=1 ozone_platform_wayland=0
 #GYP_DEFINES += use_ozone=1
@@ -253,7 +253,7 @@ endif
 ifneq ($(DEB_HOST_ARCH),$(DEB_BUILD_ARCH))
 CROSS_BUILD = PKG_CONFIG_PATH=/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig:/usr/$(DEB_HOST_MULTIARCH)/lib/pkgconfig CXX=$(DEB_HOST_GNU_TYPE)-g++ CC=$(DEB_HOST_GNU_TYPE)-gcc AR=$(DEB_HOST_GNU_TYPE)-ar AS=$(DEB_HOST_GNU_TYPE)-as CPP=$(DEB_HOST_GNU_TYPE)-cpp LD=$(DEB_HOST_GNU_TYPE)-ld
 else
-CROSS_BUILD = CC=clang CXX=clang++
+CROSS_BUILD = CC=$$(which gcc-4.8 gcc |head -1) CXX=$$(which g++-4.8 g++ |head -1)
 endif
 
 


### PR DESCRIPTION
We are experiencing a significant performance problem with the clang
builds of Chromium on Endless, with launch times that are greater
than twice that of our chromium-45 builds.

When we build chromium-48 with gcc/g++ using the debian rules from
48.0.2564.82-0ubuntu0.15.04.1.1193, as currently used in Ubuntu Vivid,
launch performance is correct again.

On 48.0.2564.82-0ubuntu1.1222, which we had previously used as the
basis of our debian rules, Ubuntu Xenial had switched to clang,
but in 49.0.2623.108-0ubuntu1.1233, Ubuntu Xenial is back to gcc/g++.

https://phabricator.endlessm.com/T11143