### PR TITLE
Fix condition to check if data has been processed when removing media elements

### DIFF
--- a/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
+++ b/third_party/WebKit/Source/core/html/HTMLMediaElement.cpp
@@ -560,7 +560,7 @@ void HTMLMediaElement::removedFrom(ContainerNode* insertionPoint)
 
     // Update the current network state based on whether we have processed data or not at
     // this point, so that we don't mistakenly call pause() or stop() below if not needed.
-    if (m_readyState == HAVE_NOTHING) {
+    if (m_readyState < HAVE_CURRENT_DATA) {
         setNetworkState(NETWORK_EMPTY);
         scheduleEvent(EventTypeNames::emptied);
     }


### PR DESCRIPTION
In a previous patch we added a (m_readyState == HAVE_NOTHING) condition to decide
when data has not been processed yet, but that's actually too strict and won't work
well when loading local resources, so let's be a bit less strict and consider the
HAVE_CURRENT_DATA state as reference instead, which seems to works fine in both cases.

https://phabricator.endlessm.com/T11073