### PR TITLE
search_engines: set Baidu a default for China

### DIFF
--- a/components/search_engines/template_url_prepopulate_data.cc
+++ b/components/search_engines/template_url_prepopulate_data.cc
@@ -124,7 +124,7 @@ const PrepopulatedEngine* engines_CL[] =
 
 // China
 const PrepopulatedEngine* engines_CN[] =
-    { &google, &baidu, &sogou, };
+    { &baidu, &sogou, &google };
 
 // Colombia
 const PrepopulatedEngine* engines_CO[] =


### PR DESCRIPTION
Instead of Google, since that is not avaialble due to network
restrictions.

https://phabricator.endlessm.com/T11618