### PR TITLE
process_singleton_posix: Remove the singleton lock file is not a symlink

### DIFF
--- a/chrome/browser/process_singleton_posix.cc
+++ b/chrome/browser/process_singleton_posix.cc
@@ -277,6 +277,12 @@ bool SymlinkPath(const base::FilePath& target, const base::FilePath& path) {
 bool ParseLockPath(const base::FilePath& path,
                    std::string* hostname,
                    int* pid) {
+  // The lock file should be a symlink, not a regular file or a directory.
+  if (base::PathExists(path) && !base::IsLink(path)) {
+      base::DeleteFile(path, true);
+      return false;
+  }
+
   std::string real_path = ReadLink(path).value();
   if (real_path.empty())
     return false;


### PR DESCRIPTION
The singleton lock file is meant to be used to check when another instance of
chromium is already running, so that a second instance being spawn can detect
that situation and send the needed data to the original browser before exiting.

For that reason, the singleton lock file is implemented as a symlink that encodes
the hostname and the PID for the original instance as the (non-existent) target,
which is information that will be checked on startup, automatically removing the
lock file if needed (e.g. original PID no longer valid, wrong hostname...).

However, one case that is not contemplated is whether the singleton lock file is
something else other than a symlink, which will be identied by ParseLockPath as a
"no lock present" situation without deleting the non-symlink file, and therefore
causing chromium to fail once it tries to create the lock later on during startup.

To prevent against this (unlikely, but possible) scenario, simply add some extra
check to ParseLockPath to make sure that only symlinks are allowed for the lock
file, and that anything else will be deleted before returning false ("no lock").

https://phabricator.endlessm.com/T11630