### PR TITLE
Install a new helper script to handle webapp://<WM_CLASS>@<URI> custom URIs

### DIFF
--- a/debian/chromium-browser-appmode.desktop
+++ b/debian/chromium-browser-appmode.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Name=Web Browser in Application Mode
+GenericName=Web Browser in application mode
+Comment=Opens a webapp:// URI in the browser, in application mode
+Exec=chromium-browser-appmode %u
+Type=Application
+Terminal=false
+NoDisplay=true
+Icon=eos-app-chromium-browser
+Categories=Network;WebBrowser;
+MimeType=x-scheme-handler/webapp;
+X-Endless-LaunchMaximized=true

--- a/debian/chromium-browser-appmode.py
+++ b/debian/chromium-browser-appmode.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python3
+#
+# chromium-browser-appmode: takes an URI like webapp://<WM_CLASS>@<ACTUAL_URI>,
+# parses it and and launches chromium-browser with --class and --app arguments.
+#
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Authors:
+#  Mario Sanchez Prada <mario@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import subprocess
+import sys
+
+class ParsingError(Exception):
+   def __init__(self, value):
+      Exception.__init__(self)
+      self.value = value
+
+   def __str__(self):
+      return repr(self.value)
+
+
+def parseURI(uri):
+   if not str.startswith(uri, 'webapp://'):
+      raise ParsingError('Wrong URI scheme')
+
+   # Get the application ID, to be used to set WM_CLASS,
+   # and the URI we want to launch in application mode.
+   uri_parts = uri[9:].split('@', 2)
+   if len(uri_parts) < 2:
+      raise ParsingError('Invalid URI format')
+
+   # First element is the value to be set as WM_CLASS,
+   # second element is the actual URI we'll launch.
+   return (uri_parts[0], uri_parts[1])
+
+
+if __name__ == '__main__':
+   if len(sys.argv[1:]) < 1:
+      print('Missing parameter')
+      sys.exit(2)
+
+   custom_uri = sys.argv[1]
+   try:
+      (wm_class, actual_uri) = parseURI(custom_uri)
+      subprocess.Popen(['chromium-browser','--class={}'.format(wm_class),'--app={}'.format(actual_uri)])
+   except ParsingError as e:
+      print('Error parsing custom URI: {}'.format(e.value))
+      print('Usage: chromium-browser-appmode webapp://<WM_CLASS>@<URI>')
+      sys.exit(2)
+   except OSError as e:
+      print('Error launching chromium: {}'.format(e.value))
+      sys.exit(2)
+
+   sys.exit(0)

--- a/debian/chromium-browser.install
+++ b/debian/chromium-browser.install
@@ -1,3 +1,4 @@
 debian/chromium-browser.desktop usr/share/applications
+debian/chromium-browser-appmode.desktop usr/share/applications
 debian/chromium-browser.xml usr/share/gnome-control-center/default-apps
 debian/apport/chromium-browser.py usr/share/apport/package-hooks/

--- a/debian/rules
+++ b/debian/rules
@@ -378,9 +378,11 @@ ifeq (1,$(COMPONENT_SHARED_LIB_BUILD))
 	find debian/*/$(LIB_DIR)      -maxdepth 1 -type f             -executable -execdir chrpath -c {} \;
 endif
 
-	# Launcher script
+	# Launcher scripts
 	cp -a debian/chromium-browser.sh debian/chromium-browser/usr/bin/chromium-browser
 	chmod 755 debian/chromium-browser/usr/bin/chromium-browser
+	cp -a debian/chromium-browser-appmode.py debian/chromium-browser/usr/bin/chromium-browser-appmode
+	chmod 755 debian/chromium-browser/usr/bin/chromium-browser-appmode
 
 	# Preferences
 	cp -a debian/chromium-browser.default debian/chromium-browser/etc/chromium-browser/default
@@ -527,6 +529,7 @@ BUILT_UNUSED_MATCH += ^usr/lib/chromium-browser/ar_sample_test_driver$$
 INDEP_MATCH = ^usr/lib/chromium-browser/.\*\(?\!\<pseudo-\)locales/.\*.pak$$
 
 PACKAGED_NOT_FROM_TREE_MATCH  = ^usr/share/applications/chromium-browser.desktop$$
+PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/applications/chromium-browser.desktop-appmode$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/apport/package-hooks/chromium-browser.py$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/doc/chromium-browser/README.source$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/doc/chromium-browser/TODO.Debian$$
@@ -538,6 +541,7 @@ PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/.\*/chromium-browser.svg$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/doc/.\*/copyright$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^usr/share/doc/.\*/changelog.Debian.gz$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^usr/bin/chromium-browser$$
+PACKAGED_NOT_FROM_TREE_MATCH += ^usr/bin/chromium-browser-appmode$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^etc/chromium-browser/default$$
 PACKAGED_NOT_FROM_TREE_MATCH += ^etc/chromium-browser/customizations/00-example$$
 


### PR DESCRIPTION
This will allow us to easily run chromium in application mode from inside
applications sandboxed with flatpak simply by using the OpenURI portal, by
specifying the desired WM_CLASS and final address to load in the custom URI.

https://phabricator.endlessm.com/T12655