### PR TITLE
Build fixup for "Enable V4L2 accelerated video decoding on Linux/ARM"

### DIFF
--- a/content/common/gpu/media/gpu_video_decode_accelerator_factory_impl.h
+++ b/content/common/gpu/media/gpu_video_decode_accelerator_factory_impl.h
@@ -89,7 +89,7 @@ public:
   scoped_ptr<media::VideoDecodeAccelerator> CreateDXVAVDA(
       const gpu::GpuPreferences& gpu_preferences) const;
 #endif
-#if defined(OS_CHROMEOS) && defined(USE_V4L2_CODEC)
+#if (defined(OS_CHROMEOS) || defined(OS_LINUX)) && defined(USE_V4L2_CODEC)
   scoped_ptr<media::VideoDecodeAccelerator> CreateV4L2VDA(
       const gpu::GpuPreferences& gpu_preferences) const;
   scoped_ptr<media::VideoDecodeAccelerator> CreateV4L2SVDA(


### PR DESCRIPTION
I broke these include guards when rebasing.

This commit should be squashed into "Enable V4L2 accelerated video decoding on Linux/ARM" during the next rebase.

https://phabricator.endlessm.com/T12671