### PR TITLE
Don't ask, always automatically open '.eck' files when downloaded

### DIFF
--- a/chrome/browser/download/chrome_download_manager_delegate.cc
+++ b/chrome/browser/download/chrome_download_manager_delegate.cc
@@ -280,6 +280,11 @@ bool ChromeDownloadManagerDelegate::ShouldOpenFileBasedOnExtension(
   if (path.MatchesExtension(extensions::kExtensionFileExtension))
     return false;
 #endif
+#if defined (OS_LINUX)
+  if (path.MatchesExtension(extensions::kExtensionEOSCodecsKeyExtension))
+    return true;
+#endif
+
   return download_prefs_->IsAutoOpenEnabledBasedOnExtension(path);
 }
 

--- a/extensions/common/constants.cc
+++ b/extensions/common/constants.cc
@@ -41,6 +41,8 @@ const base::FilePath::CharType kExtensionFileExtension[] =
     FILE_PATH_LITERAL(".crx");
 const base::FilePath::CharType kExtensionKeyFileExtension[] =
     FILE_PATH_LITERAL(".pem");
+const base::FilePath::CharType kExtensionEOSCodecsKeyExtension[] =
+    FILE_PATH_LITERAL(".eck");
 
 // If auto-updates are turned on, default to running every 5 hours.
 const int kDefaultUpdateFrequencySeconds = 60 * 60 * 5;

--- a/extensions/common/constants.h
+++ b/extensions/common/constants.h
@@ -66,6 +66,9 @@ extern const base::FilePath::CharType kExtensionFileExtension[];
 // The file extension (.pem) for private key files.
 extern const base::FilePath::CharType kExtensionKeyFileExtension[];
 
+// The file extension (.eck) for EOS Codecs Activation Keys.
+extern const base::FilePath::CharType kExtensionEOSCodecsKeyExtension[];
+
 // Default frequency for auto updates, if turned on.
 extern const int kDefaultUpdateFrequencySeconds;
 


### PR DESCRIPTION
This extension will be categorized as 'application/x-eos-codecs-key'
by our shared-mime-info deployment, meaning that our own handler for
this custom MIME type will be run on EOS when opening these types
of files, and so this is the last step needed to enable a 'one click'
experience when purchasing codecs through our online store.

https://phabricator.endlessm.com/T12939