### PR TITLE
Hopefully the last build fixup for enabling V4L2 accelerated video decoding on Linux/ARM

### DIFF
--- a/content/common/gpu/media/gpu_video_decode_accelerator_factory_impl.cc
+++ b/content/common/gpu/media/gpu_video_decode_accelerator_factory_impl.cc
@@ -125,7 +125,7 @@ GpuVideoDecodeAcceleratorFactoryImpl::CreateVDA(
 #if defined(OS_WIN)
     &GpuVideoDecodeAcceleratorFactoryImpl::CreateDXVAVDA,
 #endif
-#if defined(OS_CHROMEOS) && defined(USE_V4L2_CODEC)
+#if (defined(OS_CHROMEOS) || defined(OS_LINUX)) && defined(USE_V4L2_CODEC)
     &GpuVideoDecodeAcceleratorFactoryImpl::CreateV4L2VDA,
     &GpuVideoDecodeAcceleratorFactoryImpl::CreateV4L2SVDA,
 #endif


### PR DESCRIPTION
Ensure that the V4L2 Video Decoder Accelerator gets actually and
initialized in GpuVideoDecodeAcceleratorFactoryImpl::CreateVDA(),
so that the HW accelerated video decoder is actually used.

This commit should be squashed into "Enable V4L2 accelerated video
decoding on Linux/ARM" during the next rebase.

https://phabricator.endlessm.com/T13250