### PR TITLE
Disable the sanbox for the wallet service by default

### DIFF
--- a/components/autofill/core/browser/payments/payments_service_url.cc
+++ b/components/autofill/core/browser/payments/payments_service_url.cc
@@ -34,9 +34,20 @@ bool IsPaymentsProductionEnabled() {
   // If the command line flag exists, it takes precedence.
   const base::CommandLine* command_line =
       base::CommandLine::ForCurrentProcess();
+
+  // We assume --wallet-service-use-sandbox=0 if not present, which
+  // is the case for Chromium unless the user changes the defaults.
+  if (!command_line->HasSwitch(switches::kWalletServiceUseSandbox))
+    return true;
+
   std::string sandbox_enabled(
       command_line->GetSwitchValueASCII(switches::kWalletServiceUseSandbox));
-  return sandbox_enabled.empty() || sandbox_enabled != "1";
+
+  // Production mode is enabled only if the sandbox is not explicitly
+  // enabled by either setting --wallet-service-use-sandbox or the
+  // full version with a value, --wallet-service-use-sandbox=1 (i.e.
+  // --wallet-service-use-sandbox=0 means production mode).
+  return !sandbox_enabled.empty() && sandbox_enabled != "1";
 }
 
 GURL GetBaseSecureUrl() {


### PR DESCRIPTION
It will be only enabled if we explicitly enable in about:flags, or by
passing --wallet-service-use-sandbox[=1] via the command line.

**DO NOT MERGE YET**: pending on testing

https://phabricator.endlessm.com/T14093