### PR TITLE
Revert "Bring xdg-settings-multiexec-desktopfiles.patch from Ubuntu p…

### DIFF
--- a/chrome/browser/shell_integration_linux.cc
+++ b/chrome/browser/shell_integration_linux.cc
@@ -152,7 +152,6 @@ bool SetDefaultWebClient(const std::string& protocol) {
   argv.push_back(shell_integration_linux::GetDesktopName(env.get()));
 
   int exit_code;
-  GetChromeVersionOfScript(kXdgSettings, &argv[0]);
   bool ran_ok = LaunchXdgUtility(argv, &exit_code);
   if (ran_ok && exit_code == EXIT_XDG_SETTINGS_SYNTAX_ERROR) {
     if (GetChromeVersionOfScript(kXdgSettings, &argv[0])) {
@@ -266,11 +265,6 @@ namespace shell_integration_linux {
 
 namespace {
 
-const char kXdgSettings[] = "xdg-settings";
-
-bool GetChromeVersionOfScript(const std::string& script,
-                              std::string* chrome_version);
-
 // The Categories for the App Launcher desktop shortcut. Should be the same as
 // the Chrome desktop shortcut, so they are in the same sub-menu.
 const char kAppListCategories[] = "Network;WebBrowser;";
@@ -321,7 +315,6 @@ std::string CreateShortcutIcon(const gfx::ImageFamily& icon_images,
     argv.push_back(temp_file_path.value());
     argv.push_back(icon_name);
     int exit_code;
-    shell_integration::GetChromeVersionOfScript(kXdgSettings, &argv[0]);
     if (!shell_integration::LaunchXdgUtility(argv, &exit_code) || exit_code) {
       LOG(WARNING) << "Could not install icon " << icon_name << ".png at size "
                    << width << ".";
@@ -421,7 +414,6 @@ bool CreateShortcutInApplicationsMenu(const base::FilePath& shortcut_filename,
     argv.push_back(temp_directory_path.value());
   argv.push_back(temp_file_path.value());
   int exit_code;
-  shell_integration::GetChromeVersionOfScript(kXdgSettings, &argv[0]);
   shell_integration::LaunchXdgUtility(argv, &exit_code);
   return exit_code == 0;
 }
@@ -445,7 +437,6 @@ void DeleteShortcutInApplicationsMenu(
     argv.push_back(directory_filename.value());
   argv.push_back(shortcut_filename.value());
   int exit_code;
-  shell_integration::GetChromeVersionOfScript(kXdgSettings, &argv[0]);
   shell_integration::LaunchXdgUtility(argv, &exit_code);
 }
 

--- a/third_party/xdg-utils/scripts/xdg-desktop-icon
+++ b/third_party/xdg-utils/scripts/xdg-desktop-icon
@@ -231,16 +231,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -253,17 +248,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -274,7 +265,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -282,13 +273,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-desktop-menu
+++ b/third_party/xdg-utils/scripts/xdg-desktop-menu
@@ -427,16 +427,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -449,17 +444,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -470,7 +461,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -478,13 +469,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-email
+++ b/third_party/xdg-utils/scripts/xdg-email
@@ -183,16 +183,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -205,17 +200,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -226,7 +217,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -234,13 +225,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-icon-resource
+++ b/third_party/xdg-utils/scripts/xdg-icon-resource
@@ -223,16 +223,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -245,17 +240,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -266,7 +257,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -274,13 +265,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-mime
+++ b/third_party/xdg-utils/scripts/xdg-mime
@@ -253,16 +253,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -275,17 +270,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -296,7 +287,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -304,13 +295,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-open
+++ b/third_party/xdg-utils/scripts/xdg-open
@@ -130,16 +130,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -152,17 +147,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -173,7 +164,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -181,13 +172,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-screensaver
+++ b/third_party/xdg-utils/scripts/xdg-screensaver
@@ -158,16 +158,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -180,17 +175,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -201,7 +192,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -209,13 +200,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-settings
+++ b/third_party/xdg-utils/scripts/xdg-settings
@@ -153,16 +153,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -175,17 +170,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -196,7 +187,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -204,13 +195,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 

--- a/third_party/xdg-utils/scripts/xdg-utils-common.in
+++ b/third_party/xdg-utils/scripts/xdg-utils-common.in
@@ -20,16 +20,11 @@ first_word()
 
 #-------------------------------------------------------------
 # map a binary to a .desktop file
-# Search every desktop file in standard locations, and if one contains any
-# Exec line whose target (after resolving symlinks) is the same as the given
-# parameter file (after resolving symlinks), then print the name of that
-# desktop file. This only emits the first desktop file found. Luckily, wildcard
-# expansion is ordered, so the lexically-first filename of a match is returned.
 binary_to_desktop_file()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    binary=$(which "$1")
-    binary=$(readlink -f "$binary")
+    binary="`which "$1"`"
+    binary="`readlink -f "$binary"`"
     base="`basename "$binary"`"
     IFS=:
     for dir in $search; do
@@ -42,17 +37,13 @@ binary_to_desktop_file()
             grep -q "^Exec.*$base" "$file" || continue
             # Make sure it's a visible desktop file (e.g. not "preferred-web-browser.desktop").
             grep -Eq "^(NoDisplay|Hidden)=true" "$file" && continue
-
-            # "TryExec" isn't good enough. Only "Exec". Test every Exec in the file. Only use one.
-            grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                    while read command argumentlist; do
-                        command_full_path=$(which "$command")
-                        if [ $(readlink -f "$command_full_path") = "$binary" ]; then
-                            # Fix any double slashes that got added path composition
-                            echo "$file" | sed -e 's,//*,/,g'
-                            return  # That was out answer. Nothing else to do.
-                        fi
-                    done
+            command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+            command="`which "$command"`"
+            if [ x"`readlink -f "$command"`" = x"$binary" ]; then
+                # Fix any double slashes that got added path composition
+                echo "$file" | sed -e 's,//*,/,g'
+                return
+            fi
         done
     done
 }
@@ -63,7 +54,7 @@ binary_to_desktop_file()
 desktop_file_to_binary()
 {
     search="${XDG_DATA_HOME:-$HOME/.local/share}:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    desktop=$(basename "$1")
+    desktop="`basename "$1"`"
     IFS=:
     for dir in $search; do
         unset IFS
@@ -71,13 +62,10 @@ desktop_file_to_binary()
         file="$dir/applications/$desktop"
         [ -r "$file" ] || continue
         # Remove any arguments (%F, %f, %U, %u, etc.).
-        grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | \
-                while read command argumentlist; do
-                    # Use while-read to process one line, not all lines.
-                    command_full_path=$(which "$command")
-                    readlink -f "$command_full_path"
-                    return  # Don't continue after the first.
-                done
+        command="`grep -E "^Exec(\[[^]=]*])?=" "$file" | cut -d= -f 2- | first_word`"
+        command="`which "$command"`"
+        readlink -f "$command"
+        return
     done
 }
 


### PR DESCRIPTION
…ackaging back"

This reverts commit adfa2de1c89eca0df26b81cf6326e67742d92d9f.

It's not actually clear to me that special support for multiexec desktop
files is really needed. Upstream xdg-utils will always pick the first
Exec line in the desktop file, at least I think so, and that's exactly
what we always want.

Moreover, this patch breaks Chromium's ability to set itself as the
default browser, which -- I presume -- is what this patch must have
originally intended to fix once upon a time. Chromium's bundled copy of
xdg-utils is very old and buggy and should not be used in preference to
the system copy. We need the system copy to work properly anyway for
use by Google Chrome.

Note also that Chromium's bundled xdg-utils is not actually installed by
our Debian package (though I suspect it was in the past).

https://phabricator.endlessm.com/T14087