### PR TITLE
Move "Endless" to the end of the User Agent string

### DIFF
--- a/content/common/user_agent.cc
+++ b/content/common/user_agent.cc
@@ -192,7 +192,7 @@ std::string BuildUserAgentFromOSAndProduct(const std::string& os_info,
   std::string user_agent;
   base::StringAppendF(
       &user_agent,
-      "Mozilla/5.0 (%s) AppleWebKit/%d.%d (KHTML, like Gecko) Endless %s Safari/%d.%d",
+      "Mozilla/5.0 (%s) AppleWebKit/%d.%d (KHTML, like Gecko) %s Safari/%d.%d Endless",
       os_info.c_str(),
       WEBKIT_VERSION_MAJOR,
       WEBKIT_VERSION_MINOR,


### PR DESCRIPTION
More UA-related craziness: apparently having "Endless" between the
WebKit-related product string and the Chrome one breaks Google Inbox,
and maybe other websites so we can't do that.

Unfortunately, using "Ubuntu" or "Ubuntu Chromium/<version>" would
not work either, since those options would also mean breaking Inbox
and Netflix, respectively, so we need something else.

After doing some testing with a bunch of websites (including those
of particular interest for us) I found that moving "Endless" to
the end of the UA string seems not to break anything, maybe because
it does not get in the middle of what websites out there actually
check, so I'm now proposing the following UA string:

  Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML,
  like Gecko) Chrome/53.0.2785.143 Safari/537.36 Endless

https://phabricator.endlessm.com/T14484