### PR TITLE
Don't lie about AAC and H264 decoders when not available (free images)

### DIFF
--- a/media/base/mime_util_internal.cc
+++ b/media/base/mime_util_internal.cc
@@ -19,6 +19,8 @@
 #include "media/base/android/media_codec_util.h"
 #endif
 
+#include <dlfcn.h>
+
 namespace media {
 namespace internal {
 
@@ -338,6 +340,41 @@ void MimeUtil::InitializeMimeTypeMaps() {
   AddSupportedMediaFormats();
 }
 
+/* On Endless OS, we always build with USE_PROPRIETARY_CODECS defined
+ * and then, depending on the version of libffmpeg.so that is loaded,
+ * some non-free codecs can be available other than free ones.
+ *
+ * The problem with this approach is that Chromium will internally
+ * report that all the proprietary codecs are available regardless
+ * of the version of libffmpeg.so that is being used so we need
+ * to add some extra checks in this case at least for the codecs
+ * that Endless OS would support in the non-free version of the OS),
+ * so that users unable to reproduce certain media formats will then
+ * be reported about it, so that they can decide whether to purchase
+ * codecs activation key to unlock that particular type of content.
+ */
+static void
+checkNonFreeMIMETypesOnEOS(bool& supports_h264, bool& supports_aac) {
+    /* Get a handle for the current process */
+    void *handle = dlopen(nullptr, RTLD_NOW);
+    if (!handle) {
+      DVLOG(4) << __FUNCTION__ << ": Unable to obtain handle for main process: " << dlerror();
+      return;
+    }
+
+#if defined(__arm__)
+    // We support H.264 / AAC hardware accelerated decoding on ARM.
+    supports_h264 = true;
+    supports_aac = true;
+#else
+    // On Intel, we check the ffmpeg-based decoders are available.
+    supports_h264 = (dlsym(handle, "ff_h264_decoder") != nullptr);
+    supports_aac = (dlsym(handle, "ff_aac_decoder") != nullptr);
+#endif
+
+    dlclose(handle);
+}
+
 // Each call to AddContainerWithCodecs() contains a media type
 // (https://en.wikipedia.org/wiki/Media_type) and corresponding media codec(s)
 // supported by these types/containers.
@@ -367,15 +404,22 @@ void MimeUtil::AddSupportedMediaFormats() {
   webm_codecs.insert(webm_video_codecs.begin(), webm_video_codecs.end());
 
 #if defined(USE_PROPRIETARY_CODECS)
+  bool supportsH264 = false;
+  bool supportsAAC = false;
+  checkNonFreeMIMETypesOnEOS(supportsH264, supportsAAC);
+
   CodecSet mp3_codecs;
   mp3_codecs.insert(MP3);
 
   CodecSet aac;
-  aac.insert(MPEG2_AAC);
-  aac.insert(MPEG4_AAC);
-
   CodecSet avc_and_aac(aac);
-  avc_and_aac.insert(H264);
+  if (supportsAAC) {
+    aac.insert(MPEG2_AAC);
+    aac.insert(MPEG4_AAC);
+
+    if (supportsH264)
+        avc_and_aac.insert(H264);
+  }
 
   CodecSet mp4_audio_codecs(aac);
   mp4_audio_codecs.insert(MP3);
@@ -385,7 +429,8 @@ void MimeUtil::AddSupportedMediaFormats() {
 #endif  // BUILDFLAG(ENABLE_AC3_EAC3_AUDIO_DEMUXING)
 
   CodecSet mp4_video_codecs;
-  mp4_video_codecs.insert(H264);
+  if (supportsH264)
+      mp4_video_codecs.insert(H264);
 #if BUILDFLAG(ENABLE_HEVC_DEMUXING)
   mp4_video_codecs.insert(HEVC);
 #endif  // BUILDFLAG(ENABLE_HEVC_DEMUXING)
@@ -415,13 +460,20 @@ void MimeUtil::AddSupportedMediaFormats() {
   AddContainerWithCodecs("audio/x-mp3", implicit_codec, true);
   AddContainerWithCodecs("audio/aac", implicit_codec, true);  // AAC / ADTS.
   AddContainerWithCodecs("audio/mp4", mp4_audio_codecs, true);
-  DCHECK(!mp4_video_codecs.empty());
-  AddContainerWithCodecs("video/mp4", mp4_codecs, true);
+
+  if (supportsH264) {
+    DCHECK(!mp4_video_codecs.empty());
+    AddContainerWithCodecs("video/mp4", mp4_codecs, true);
+  }
   // These strings are supported for backwards compatibility only and thus only
   // support the codecs needed for compatibility.
-  AddContainerWithCodecs("audio/x-m4a", aac, true);
-  AddContainerWithCodecs("video/x-m4v", avc_and_aac, true);
 
+  if (supportsAAC) {
+    AddContainerWithCodecs("audio/x-m4a", aac, true);
+
+    if (supportsH264)
+      AddContainerWithCodecs("video/x-m4v", avc_and_aac, true);
+  }
 #if BUILDFLAG(ENABLE_MSE_MPEG2TS_STREAM_PARSER)
   // TODO(ddorwin): Exactly which codecs should be supported?
   DCHECK(!mp4_video_codecs.empty());


### PR DESCRIPTION
On Endless OS, we always build with USE_PROPRIETARY_CODECS defined
and then, depending on the version of libffmpeg.so that is loaded,
some non-free codecs can be available other than free ones.

The problem with this approach is that Chromium will internally
report that all the proprietary codecs are available regardless
of the version of libffmpeg.so that is being used so we need
to add some extra checks in this case at least for the codecs
that Endless OS would support in the non-free version of the OS),
so that users unable to reproduce certain media formats will then
be reported about it, so that they can decide whether to purchase
codecs activation key to unlock that particular type of content.

This patch double-checks whether the AAC and H264 decoders are really
available at run-time before adding the related MIME type to the list
of supported formats, so that we have a chance to let users know that
they might need to upgrade to a non-free version of Endless OS.

Note that this change only makes a difference for Intel, as we always
support hardware-based acceleration for H264 and AAC on ARM.

https://phabricator.endlessm.com/T15216