### PR TITLE
Don't consider swap memory for the automatic tab discarding feature

### DIFF
--- a/base/memory/memory_pressure_monitor_endless.cc
+++ b/base/memory/memory_pressure_monitor_endless.cc
@@ -142,14 +142,11 @@ int MemoryPressureMonitor::GetUsedMemoryInPercent() {
     return 0;
   }
 
-  // The available memory consists of "real" and virtual (z)ram memory.
-  // Since swappable memory uses a non pre-deterministic compression and
-  // the compression creates its own "dynamic" in the system, it gets
-  // de-emphasized by the |kSwapWeight| factor.
-  const int kSwapWeight = 4;
-
-  // The total memory we have is the "real memory" plus the virtual (z)ram.
-  int total_memory = info.total + info.swap_total / kSwapWeight;
+  // The total memory we have is the "real memory" ONLY. We don't consider
+  // virtual (z)ram on Endless since we're shipping products with low RAM
+  // and bigger swap partitions on spinning disks, which would cause the
+  // machine to slow down even before a tab discarding situation is reached.
+  int total_memory = info.total;
 
   // The kernel internally uses 50MB.
   const int kMinFileMemory = 50 * 1024;
@@ -159,9 +156,8 @@ int MemoryPressureMonitor::GetUsedMemoryInPercent() {
   // unless it is dirty or it's a minimal portion which is required.
   file_memory -= info.dirty + kMinFileMemory;
 
-  // Available memory is the sum of free, swap and easy reclaimable memory.
-  int available_memory =
-      info.free + info.swap_free / kSwapWeight + file_memory;
+  // Available memory is the sum of free and easy reclaimable memory (no swap).
+  int available_memory = info.free + file_memory;
 
   DCHECK(available_memory < total_memory);
   int percentage = ((total_memory - available_memory) * 100) / total_memory;

--- a/chrome/browser/ui/webui/about_ui.cc
+++ b/chrome/browser/ui/webui/about_ui.cc
@@ -552,8 +552,6 @@ std::string AboutDiscards(const std::string& path) {
   // Start with summary statistics.
   output.append(AddStringRow("Total", base::IntToString(meminfo.total / 1024)));
   output.append(AddStringRow("Free RAM", base::IntToString(meminfo.free / 1024)));
-  output.append(AddStringRow("Swap Total", base::IntToString(meminfo.swap_total / 1024)));
-  output.append(AddStringRow("Swap Free", base::IntToString(meminfo.swap_free / 1024)));
   output.append(AddStringRow("Cached", base::IntToString(meminfo.cached / 1024)));
   output.append(AddStringRow("Buffers", base::IntToString(meminfo.buffers / 1024)));
   output.append(AddStringRow("Cached+Buffers", base::IntToString((meminfo.cached + meminfo.buffers) / 1024)));
@@ -562,10 +560,10 @@ std::string AboutDiscards(const std::string& path) {
   output.append(AddStringRow("Dirty", base::IntToString(meminfo.dirty / 1024)));
 
   // Check base::endless::MemoryPressureMonitor::GetUsedMemoryInPercent to know where these values come from.
-  const int kSwapWeight = 4, kMinFileMemory = 50 * 1024;
-  int total_memory = meminfo.total + meminfo.swap_total / kSwapWeight;
+  const int kMinFileMemory = 50 * 1024;
+  int total_memory = meminfo.total;
   int file_memory = meminfo.active_file + meminfo.inactive_file - meminfo.dirty - kMinFileMemory;
-  int available_memory = meminfo.free + meminfo.swap_free / kSwapWeight + file_memory;
+  int available_memory = meminfo.free + file_memory;
   int percentage = ((total_memory - available_memory) * 100) / total_memory;
   output.append(AddStringRow("Memory in use (%)", base::IntToString(percentage)));
 


### PR DESCRIPTION
On Endless, we ship products with little RAM (e.g. 2G) and a big
swap partition (e.g. 2xRAM = 4G), often located on a spinning
disk (e.g. Endlss / Mission One). This causes problems because
the automatic tab discards feature won't kick-in until 80% of the
total memory is in use, including swap, causing a big slow down
of the whole system since at that point not much RAM will be
available, and the computer will be already paging out a lot.

To reduce this problem, let's consider only "real memory" in our
memory pressure monitor, even if that will mean discarding much
earlier than before in those kind of systems.

https://phabricator.endlessm.com/T15373