### PR TITLE
work around SYS_getrandom build failure on ARM

### DIFF
--- a/third_party/boringssl/src/crypto/rand/urandom.c
+++ b/third_party/boringssl/src/crypto/rand/urandom.c
@@ -41,6 +41,16 @@
 
 #if defined(OPENSSL_LINUX)
 
+/*
+ * suppress SYS_getrandom definition as our kernel headers don't have
+ * __NR_getrandom. the macros below assume that SYS_getrandom is declared if
+ * it's defined, which is not true if you have a new glibc but old kernel
+ * headers, because sys/syscall.h has #define SYS_getrandom __NR_getrandom.
+ */
+#if !defined(__NR_getrandom)
+#undef SYS_getrandom
+#endif
+
 #if defined(OPENSSL_X86_64)
 #define EXPECTED_SYS_getrandom 318
 #elif defined(OPENSSL_X86)


### PR DESCRIPTION
Chromium ships with some nice headers that define all of the missing __NR_getrandom syscall numbers, but boringssl does not use them. This adds a simple hack to suppress SYS_getrandom definition, because our 3.8 kernel headers on ARM don't have __NR_getrandom. The macros in this file assume that SYS_getrandom is declared if it's defined, which is not true for us, because the glibc sys/syscall.h just does #define SYS_getrandom __NR_getrandom. If we just undefine SYS_getrandom, this file will use it's hardcoded value from EXPECTED_SYS_getrandom, which means it will build OK and will fall back when it discovers the syscall is unavailable at runtime.

https://phabricator.endlessm.com/T17003