### PR TITLE
Import fix-argument-evaluation-order.patch from Ubuntu

### DIFF
--- a/extensions/browser/api/networking_private/networking_private_linux.cc
+++ b/extensions/browser/api/networking_private/networking_private_linux.cc
@@ -211,11 +211,13 @@ void NetworkingPrivateLinux::GetState(
       new base::DictionaryValue);
 
   // Runs GetCachedNetworkProperties on |dbus_thread|.
+  std::string* erp = error.get();
+  base::DictionaryValue* npp = network_properties.get();
   dbus_thread_.task_runner()->PostTaskAndReply(
       FROM_HERE, base::Bind(&NetworkingPrivateLinux::GetCachedNetworkProperties,
                             base::Unretained(this), guid,
-                            base::Unretained(network_properties.get()),
-                            base::Unretained(error.get())),
+                            base::Unretained(npp),
+                            base::Unretained(erp)),
       base::Bind(&GetCachedNetworkPropertiesCallback, base::Passed(&error),
                  base::Passed(&network_properties), success_callback,
                  failure_callback));
@@ -298,11 +300,12 @@ void NetworkingPrivateLinux::GetNetworks(
 
   // Runs GetAllWiFiAccessPoints on the dbus_thread and returns the
   // results back to OnAccessPointsFound where the callback is fired.
+  NetworkMap* nmp = network_map.get();
   dbus_thread_.task_runner()->PostTaskAndReply(
       FROM_HERE,
       base::Bind(&NetworkingPrivateLinux::GetAllWiFiAccessPoints,
                  base::Unretained(this), configured_only, visible_only, limit,
-                 base::Unretained(network_map.get())),
+                 base::Unretained(nmp)),
       base::Bind(&NetworkingPrivateLinux::OnAccessPointsFound,
                  base::Unretained(this), base::Passed(&network_map),
                  success_callback, failure_callback));
@@ -318,11 +321,12 @@ bool NetworkingPrivateLinux::GetNetworksForScanRequest() {
   // Runs GetAllWiFiAccessPoints on the dbus_thread and returns the
   // results back to SendNetworkListChangedEvent to fire the event. No
   // callbacks are used in this case.
+  NetworkMap* nmp = network_map.get();
   dbus_thread_.task_runner()->PostTaskAndReply(
       FROM_HERE, base::Bind(&NetworkingPrivateLinux::GetAllWiFiAccessPoints,
                             base::Unretained(this), false /* configured_only */,
                             false /* visible_only */, 0 /* limit */,
-                            base::Unretained(network_map.get())),
+                            base::Unretained(nmp)),
       base::Bind(&NetworkingPrivateLinux::OnAccessPointsFoundViaScan,
                  base::Unretained(this), base::Passed(&network_map)));
 
@@ -504,10 +508,11 @@ void NetworkingPrivateLinux::StartConnect(
   std::unique_ptr<std::string> error(new std::string);
 
   // Runs ConnectToNetwork on |dbus_thread|.
+  std::string* erp = error.get();
   dbus_thread_.task_runner()->PostTaskAndReply(
       FROM_HERE,
       base::Bind(&NetworkingPrivateLinux::ConnectToNetwork,
-                 base::Unretained(this), guid, base::Unretained(error.get())),
+                 base::Unretained(this), guid, base::Unretained(erp)),
       base::Bind(&OnNetworkConnectOperationCompleted, base::Passed(&error),
                  success_callback, failure_callback));
 }
@@ -522,10 +527,11 @@ void NetworkingPrivateLinux::StartDisconnect(
   std::unique_ptr<std::string> error(new std::string);
 
   // Runs DisconnectFromNetwork on |dbus_thread|.
+  std::string* erp = error.get();
   dbus_thread_.task_runner()->PostTaskAndReply(
       FROM_HERE,
       base::Bind(&NetworkingPrivateLinux::DisconnectFromNetwork,
-                 base::Unretained(this), guid, base::Unretained(error.get())),
+                 base::Unretained(this), guid, base::Unretained(erp)),
       base::Bind(&OnNetworkConnectOperationCompleted, base::Passed(&error),
                  success_callback, failure_callback));
 }


### PR DESCRIPTION
Fix order of evaluation bug in networking_private extension.
Only builds where is_clang=false are affected.

Origin: https://bugs.chromium.org/p/chromium/issues/detail?id=572539
Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=734325
Bug-Ubuntu: https://launchpad.net/bugs/1702407