### PR TITLE
Fix loading of the vendor EGL/GLES stack on ARM

### DIFF
--- a/ui/gl/init/gl_initializer_x11.cc
+++ b/ui/gl/init/gl_initializer_x11.cc
@@ -37,8 +37,10 @@ const char kGLLibraryName[] = "libGL.so.1";
 const char kGLESv2LibraryName[] = "libGLESv2.so.2";
 const char kEGLLibraryName[] = "libEGL.so.1";
 
+#if !defined (__ARMEL__)
 const char kGLESv2ANGLELibraryName[] = "libGLESv2.so";
 const char kEGLANGLELibraryName[] = "libEGL.so";
+#endif
 
 #if BUILDFLAG(ENABLE_SWIFTSHADER)
 const char kGLESv2SwiftShaderLibraryName[] = "libGLESv2.so";
@@ -97,6 +99,7 @@ bool InitializeStaticEGLInternal(GLImplementation implementation) {
 #else
     return false;
 #endif
+#if !defined (__ARMEL__)
   } else {
     base::FilePath module_path;
     if (!PathService::Get(base::DIR_MODULE, &module_path))
@@ -104,6 +107,7 @@ bool InitializeStaticEGLInternal(GLImplementation implementation) {
 
     glesv2_path = module_path.Append(kGLESv2ANGLELibraryName);
     egl_path = module_path.Append(kEGLANGLELibraryName);
+#endif
   }
 
   base::NativeLibrary gles_library = LoadLibraryAndPrintError(glesv2_path);


### PR DESCRIPTION
In chromium 61 this code path has been altered and it is
no longer possible for the system EGL/GLES implementation
to be loaded. Instead, chromium's internal ANGLE implementation
is always loaded. Unfortunately, ANGLE is unusable because
it only has a GLX backend on X11.

This also fixes v4l2 video decode acceleration, which is not
possible without certain EGL extensions.

https://bugs.chromium.org/p/chromium/issues/detail?id=778264
https://phabricator.endlessm.com/T19660
