### PR TITLE
v4l2_VDA: fix a deadlock that can happen when switching resolutions

### DIFF
--- a/media/gpu/v4l2_video_decode_accelerator.cc
+++ b/media/gpu/v4l2_video_decode_accelerator.cc
@@ -1160,11 +1160,19 @@ bool V4L2VideoDecodeAccelerator::FlushInputFrame() {
   return (decoder_state_ != kError);
 }
 
-void V4L2VideoDecodeAccelerator::ServiceDeviceTask(bool event_pending) {
+void V4L2VideoDecodeAccelerator::ServiceDeviceTask(bool event_pending,
+        base::PlatformThreadId scheduled_from) {
   DVLOGF(3);
   DCHECK(decoder_thread_.task_runner()->BelongsToCurrentThread());
   DCHECK_NE(decoder_state_, kUninitialized);
   TRACE_EVENT0("Video Decoder", "V4L2VDA::ServiceDeviceTask");
+
+  // break task scheduling sequence in case the device_poll_thread_ restarts
+  if (scheduled_from != device_poll_thread_.GetThreadId()) {
+    DVLOGF(3) << "task was scheduled from a thread that no longer exists;"
+        << " exiting";
+    return;
+  }
 
   if (decoder_state_ == kResetting) {
     DVLOGF(3) << "early out: kResetting state";
@@ -1978,7 +1986,8 @@ void V4L2VideoDecodeAccelerator::DevicePollTask(bool poll_device) {
   // touch decoder state from this thread.
   decoder_thread_.task_runner()->PostTask(
       FROM_HERE, base::Bind(&V4L2VideoDecodeAccelerator::ServiceDeviceTask,
-                            base::Unretained(this), event_pending));
+                            base::Unretained(this), event_pending,
+                            device_poll_thread_.GetThreadId()));
 }
 
 void V4L2VideoDecodeAccelerator::NotifyError(Error error) {

--- a/media/gpu/v4l2_video_decode_accelerator.h
+++ b/media/gpu/v4l2_video_decode_accelerator.h
@@ -270,7 +270,8 @@ class MEDIA_GPU_EXPORT V4L2VideoDecodeAccelerator
   // Service I/O on the V4L2 devices.  This task should only be scheduled from
   // DevicePollTask().  If |event_pending| is true, one or more events
   // on file descriptor are pending.
-  void ServiceDeviceTask(bool event_pending);
+  void ServiceDeviceTask(bool event_pending,
+                         base::PlatformThreadId scheduled_from);
   // Handle the various device queues.
   void Enqueue();
   void Dequeue();


### PR DESCRIPTION
The root cause of the deadlock is this:

ServiceDeviceTask() and DevicePollTask() are meant to run in sequence
and activate one another. But, they run from different threads.
Normally, StartDevicePoll() schedules a call to DevicePollTask(),
which then in turn schedules ServiceDeviceTask(), which schedules
DevicePollTask() again and they continue like this.

When switching resolutions, there is an interesting chain of events:
1) ServiceDeviceTask() schedules DevicePollTask()
2) DevicePollTask() now runs in the other thread in parallel to
   ServiceDeviceTask()
3) DevicePollTask() schedules ServiceDeviceTask()
4) the previous ServiceDeviceTask() at the same time calls
   StartResolutionChange() before returning
5) StartResolutionChange() causes the thread that runs DevicePollTask()
   to get restarted by calling StopDevicePoll() & StartDevicePoll()
6) StartDevicePoll() schedules DevicePollTask()
7) ServiceDeviceTask() returns and runs again because it was scheduled
   earlier in (3)
8) ServiceDeviceTask() schedules DevicePollTask()
-> At this point we've ended up with 2 scheduled calls to DevicePollTask(),
which are going to schedule 2 calls to ServiceDeviceTask() and so forth,
which leads to problems.

The deadlock situation happens when at some point ServiceDeviceTask()
schedules DevicePollTask() with poll_device=false because there are no
input or output buffers available, but then the next ServiceDeviceTask()
(which runs immediately because there are always 2 of them scheduled)
gets an output buffer and schedules DevicePollTask with poll_device=true.
At this point, the state of the VDA is such that it is waiting for an event
from the v4l device, but DevicePollTask() has called poll() without the
device fd, and therefore the event is never received.

The solution that is implemented in this patch is basically to break
the chain of calls when it is detected that device_poll_thread_ has
been restarted. With this additional check, at event (7) in the above
example, ServiceDeviceTask() will return early and do nothing, because
it will detect that it was scheduled by the previous device_poll_thread_
and not the current one.

https://phabricator.endlessm.com/T18312