### PR TITLE
Fix fast path for opening files when the browser is already running

### DIFF
--- a/debian/chromium-browser.sh.in
+++ b/debian/chromium-browser.sh.in
@@ -232,7 +232,11 @@ else
       hexargs="$hexargs$(echo -ne "\0$arg" | xxd -p)"
     done
 
-    if echo $hexargs | sed "s/^00//" | xxd -r -p | nc -U "$HOME/.config/chromium/SingletonSocket" 2> /dev/null | grep "^ACK$" > /dev/null; then
+    # The command nc can point either to nc.traditional or to nc.openbsd depending
+    # on the configuratino of alternatives, but we DO want nc.openbsd for sure (the
+    # other one does not have an -U parameter) so we'd better call it directly not
+    # to risk issues if configuration changes at some point.
+    if echo $hexargs | sed "s/^00//" | xxd -r -p | nc.openbsd -NU "$HOME/.config/chromium/SingletonSocket" 2> /dev/null | grep "^ACK$" > /dev/null; then
       exit 0
     fi
   fi

--- a/debian/control
+++ b/debian/control
@@ -49,6 +49,7 @@ Pre-Depends: dpkg (>= 1.15.6)
 Depends: ${shlibs:Depends}, ${misc:Depends},
 	bash (>= 4),
 	libnss3,
+	netcat-openbsd (>= 1.110),
 	xdg-utils,
 	chromium-codecs-ffmpeg (= ${binary:Version}),
 	chromium-browser-l10n


### PR DESCRIPTION
The current call to nc in there has stopped working in recent versions
of nc.openbsd because a fix in that version[1] has caused nc.openbsd to
block forever in certain scenarios, as it's the cases such as qemu[2]
or in here with chromium-browser.

To avoid this issue we can simply specify the new -N parameter, so that
shutdown(2) is called over the socket after passing EOF on the input. This
new option has been added in netcat-openbsd 1.110, so we need a versioned
dependency in debian/control as well.

This should be squashed into commit 7bd01a57 in future rebases.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=849192
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=854292

https://phabricator.endlessm.com/T20071