### PR TITLE
Enable back protection time for automatic tab discarding

### DIFF
--- a/chrome/browser/resource_coordinator/tab_manager.cc
+++ b/chrome/browser/resource_coordinator/tab_manager.cc
@@ -213,8 +213,8 @@ TabManager::TabManager()
     : discard_count_(0),
       recent_tab_discard_(false),
       discard_once_(false),
-#if !defined(OS_CHROMEOS) && !defined(OS_LINUX)
-      minimum_protection_time_(base::TimeDelta::FromMinutes(10)),
+#if !defined(OS_CHROMEOS)
+      minimum_protection_time_(base::TimeDelta::FromMinutes(5)),
 #endif
       browser_tab_strip_tracker_(this, nullptr, this),
       test_tick_clock_(nullptr),


### PR DESCRIPTION
We set 5 minutes instead of the default 10 minutes to be
ellegible for discarding.

https://phabricator.endlessm.com/T18987