### PR TITLE
Revert "Ensure Exploration Center is enabled by default"

### DIFF
--- a/extensions/browser/extension_prefs.cc
+++ b/extensions/browser/extension_prefs.cc
@@ -1853,11 +1853,6 @@ void ExtensionPrefs::PopulateExtensionInfoPrefs(
     extension_dict->SetBoolean(kPrefDoNotSync, true);
   else
     extension_dict->Remove(kPrefDoNotSync, NULL);
-
-  // Evil hack to ensure Exploration Center is enabled by default.
-  // There has to be a better way to do this.
-  if (extension->id() == "fpmnjlkappdkncfmjefheaidpmbmfdfk")
-    const_cast<ExtensionPrefs*>(this)->SetExtensionEnabled(extension->id());
 }
 
 void ExtensionPrefs::InitExtensionControlledPrefs(


### PR DESCRIPTION
Finally, we have fixed the way the extension is installed and
managed via Group Policies and this hack can be now exterminated.

This reverts commit 31d89e7bcf9bb283c4d08b46abdb2c47331996ee.

https://phabricator.endlessm.com/T16331