### PR TITLE
Revert "Remove StartupNotify=true from desktop file for now"

### DIFF
--- a/debian/chromium-browser.desktop
+++ b/debian/chromium-browser.desktop
@@ -174,6 +174,7 @@ Type=Application
 Icon=chromium-browser
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml_xml;x-scheme-handler/http;x-scheme-handler/https;
+StartupNotify=true
 Actions=NewWindow;Incognito;TempProfile;
 X-AppInstall-Package=chromium-browser
 


### PR DESCRIPTION
This is no longer needed since we now have the Startup Notification
Protocol [1] properly implemented both for primary and remote instances.

This reverts commit f51beade74254a4ddc3810b31fbda17789989f4c.

[1] http://standards.freedesktop.org/startup-notification-spec/startup-notification-latest.txt

https://phabricator.endlessm.com/T22506