### PR TITLE
chrome/browser: Fix startup notification protocol for the primary instance

### DIFF
--- a/chrome/browser/after_startup_task_utils.cc
+++ b/chrome/browser/after_startup_task_utils.cc
@@ -27,6 +27,10 @@
 #include "content/public/browser/web_contents_observer.h"
 #include "third_party/WebKit/public/mojom/page/page_visibility_state.mojom.h"
 
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+#include "ui/views/linux_ui/linux_ui.h"
+#endif
+
 using content::BrowserThread;
 using content::WebContents;
 using content::WebContentsObserver;
@@ -120,6 +124,14 @@ void SetBrowserStartupIsComplete() {
   // The shrink_to_fit() method is not available for all of our build targets.
   base::circular_deque<AfterStartupTask*>(g_after_startup_tasks.Get())
       .swap(g_after_startup_tasks.Get());
+
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  // Make sure we complete the startup notification sequence, or launchers will
+  // get confused by not receiving the expected message from the main process.
+  views::LinuxUI* linux_ui = views::LinuxUI::instance();
+  if (linux_ui)
+    linux_ui->NotifyWindowManagerStartupComplete();
+#endif
 }
 
 // Observes the first visible page load and sets the startup complete

--- a/ui/views/linux_ui/linux_ui.h
+++ b/ui/views/linux_ui/linux_ui.h
@@ -165,9 +165,9 @@ class VIEWS_EXPORT LinuxUI : public ui::LinuxInputMethodContextFactory,
       NonClientWindowFrameActionSourceType source) = 0;
 
   // Notifies the window manager that start up has completed.
-  // Normally Chromium opens a new window on startup and GTK does this
-  // automatically. In case Chromium does not open a new window on startup,
-  // e.g. an existing browser window already exists, this should be called.
+  // This needs to be called explicitly both on the primary and the "remote"
+  // instances (e.g. an existing browser window already exists), since we no
+  // longer use GTK (which did this automatically) for the main windows.
   virtual void NotifyWindowManagerStartupComplete() = 0;
 
   // Updates the device scale factor so that the default font size can be


### PR DESCRIPTION
At the moment, chromium's implementation of the startup notification protocol
does only make sure that the window manager gets notified when the startup
process finishes for non-primary instances of the main process, that is,
when the user attempts to spawn a new chromium-browser process while another
instance is already running.

This is because ProcessSingleton::NotifyOtherProcessWithTimeout() is the only
placed where NotifyWindowManagerStartupComplete() is being called, which used
to be fine when chromium relied on GTK+ for its top-level windows (GTK+ calls
gdk_display_notify_startup_complete() when mapping the top-level window) in
the past, but now that chromium relies on Aura, it's necessary to add another
explicit call in the codepath that completes startup for the main instance.

[1] http://standards.freedesktop.org/startup-notification-spec/startup-notification-latest.txt

https://phabricator.endlessm.com/T22506