### PR TITLE
Fix override of User-Agent string for ARM and Google Calendar

### DIFF
--- a/content/browser/frame_host/navigation_request.cc
+++ b/content/browser/frame_host/navigation_request.cc
@@ -9,6 +9,7 @@
 #include "base/optional.h"
 #include "base/strings/string_util.h"
 #include "build/build_config.h"
+#include "chrome/common/chrome_switches.h"
 #include "content/browser/appcache/appcache_navigation_handle.h"
 #include "content/browser/appcache/chrome_appcache_service.h"
 #include "content/browser/child_process_security_policy_impl.h"
@@ -139,6 +140,38 @@ bool NeedsHTTPOrigin(net::HttpRequestHeaders* headers,
   return true;
 }
 
+// Helper function we use on EndlessOS to alter the UserAgent string.
+std::string AdaptUserAgentForURL(const std::string& user_agent, const GURL& url) {
+  std::string result = user_agent;
+
+  // Can't make a decision is no valid URL has been passed.
+  if (url.is_empty() || !url.is_valid())
+	return result;
+
+  // Early return if the --user-agent parameter has been passed,
+  // since we still want to be able to use its value if specified.
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kUserAgent)) {
+    std::string ua = command_line->GetSwitchValueASCII(switches::kUserAgent);
+    LOG(INFO) << "LOG :: User Agent specified via --user-agent ('" << ua << "'). Ignoring Endless-specific overrides";
+    return result;
+  }
+
+#ifdef __arm__
+  // With the default user agent string, containing the '(X11; Linux armv7l)' part, Google
+  // Calendar redirect to their mobile version, so send 'Linux x86_64' instead.
+  const std::string& host = url.host();
+  if ((host.find("calendar.google.com") != std::string::npos) ||
+      (host.find("google.com") != std::string::npos && url.path().find("/calendar") == 0)) {
+	std::string::size_type start_pos = user_agent.find('(');
+	std::string::size_type end_pos = user_agent.find(')');
+	result.replace(start_pos, end_pos - start_pos, std::string("X11; Linux x86_64"));
+  }
+#endif
+
+  return result;
+}
+
 // TODO(clamy): This should match what's happening in
 // blink::FrameFetchContext::addAdditionalRequestHeaders.
 void AddAdditionalRequestHeaders(
@@ -176,7 +209,7 @@ void AddAdditionalRequestHeaders(
 
   headers->SetHeaderIfMissing(net::HttpRequestHeaders::kUserAgent,
                               user_agent_override.empty()
-                                  ? GetContentClient()->GetUserAgent()
+                                  ? AdaptUserAgentForURL(GetContentClient()->GetUserAgent(), url)
                                   : user_agent_override);
 
   // Next, set the HTTP Origin if needed.

--- a/third_party/blink/renderer/core/loader/frame_loader.cc
+++ b/third_party/blink/renderer/core/loader/frame_loader.cc
@@ -111,12 +111,6 @@ namespace blink {
 
 using namespace HTMLNames;
 
-// Helper function we use on EndlessOS to alter the UserAgent string
-// returned by chromium's content layer based on the frame's URL.
-String adaptUserAgentForURL(const String& userAgent, const KURL& url) {
-  return userAgent;
-}
-
 bool IsBackForwardLoadType(FrameLoadType type) {
   return type == kFrameLoadTypeBackForward ||
          type == kFrameLoadTypeInitialHistoryLoad;
@@ -1292,13 +1286,8 @@ void FrameLoader::RestoreScrollPositionAndViewState(
 }
 
 String FrameLoader::UserAgent() const {
-  String clientUserAgent = Client()->UserAgent();
-  // On Endless, we need to still be able to alter the UserAgent string depending
-  // on the URL we are loading, so we adapt it if needed before applying it. But we
-  // might not have a committed load, so we first check the URL from the provisional
-  // loader before trying with the regular one, so that we always get a valid URL.
-  const DocumentLoader& activeLoader = provisional_document_loader_.Get() ? *provisional_document_loader_ : *document_loader_;
-  String user_agent = adaptUserAgentForURL(clientUserAgent, activeLoader.GetRequest().Url());
+  String user_agent = Client()->UserAgent();
+  probe::applyUserAgentOverride(frame_->GetDocument(), &user_agent);
   return user_agent;
 }
 

--- a/third_party/blink/renderer/core/loader/frame_loader.cc
+++ b/third_party/blink/renderer/core/loader/frame_loader.cc
@@ -114,36 +114,6 @@ using namespace HTMLNames;
 // Helper function we use on EndlessOS to alter the UserAgent string
 // returned by chromium's content layer based on the frame's URL.
 String adaptUserAgentForURL(const String& userAgent, const KURL& url) {
-#ifdef __arm__
-  if (url.IsEmpty() || !url.IsValid())
-    return userAgent;
-
-  const String& host = url.Host();
-  String userAgentOS;
-
-  // With the default Linux user agent, Netflix presents a cryptic error when
-  // trying to play back video. Pretend to be CrOS.
-  if (host.Contains("netflix.com") || host.Contains("nflxvideo.net"))
-    userAgentOS = String::FromUTF8("X11; CrOS armv7l 7262.57.0");
-
-  // With the default user agent string, containing the '(X11; Linux armv7l)' part, Google
-  // Calendar and Yahoo redirect to their mobile version, so send 'Linux i686' instead.
-  if (host.Contains("calendar.google.com") ||
-      (host.Contains("google.com") && url.GetPath().StartsWith("/calendar")) ||
-      host.Contains("yahoo.com"))
-    userAgentOS = String::FromUTF8("X11; Linux i686");
-
-  if (!userAgentOS.IsEmpty()) {
-    // Replace the OS part of the UserAgent string if needed.
-    StringBuilder builder;
-    builder.Append(userAgent.Left(userAgent.find('(') + 1));
-    builder.Append(userAgentOS);
-    builder.Append(userAgent.Substring(userAgent.find(')')));
-
-    return builder.ToString();
-  }
-#endif
-
   return userAgent;
 }
 


### PR DESCRIPTION
PS: This is no longer necessary for Yahoo or Netflix, so this PR doesn't implement those, just removes them from the Blink code without porting them to the new location.

https://phabricator.endlessm.com/T5666