### PR TITLE
debian/control: Add build dependency on libeosopenh264-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Build-Depends:
 	libasound2-dev,
 	libnss3-dev,
 	mesa-common-dev,
+	libnoopenh264-dev,
 	libfdk-aac-dev,
 	libgles2-mesa-dev [armel armhf],
 	libpci-dev,


### PR DESCRIPTION
This is now needed to support for Cisco's implementation of OpenH264.

https://phabricator.endlessm.com/T23345