### PR TITLE
Tweak memory pressure thresholds for cache/tab discarding

### DIFF
--- a/base/memory/memory_pressure_monitor_endless.cc
+++ b/base/memory/memory_pressure_monitor_endless.cc
@@ -28,8 +28,8 @@ const int kModerateMemoryPressureCooldownMs = 10000;
 const int kModerateMemoryPressureCooldown = kModerateMemoryPressureCooldownMs / kMemoryPressureIntervalMs;
 
 // Default threshold (as in % of used memory) for emission of memory pressure events.
-const int kDefaultMemoryPressureModerateThreshold = 45;
-const int kDefaultMemoryPressureCriticalThreshold = 80;
+const int kDefaultMemoryPressureModerateThreshold = 50;
+const int kDefaultMemoryPressureCriticalThreshold = 70;
 
 MemoryPressureMonitor::MemoryPressureMonitor()
     : current_memory_pressure_level_(MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE)


### PR DESCRIPTION
Now that we include 25% of the zram in the available/total calculations, the
tab discard threshold is set too high because if you have other apps loaded, we
can easily leave the machine swapping/thrashing before we discard any tabs and
relieve memory pressure. The "aggressive tab discard" level in ChromeOS is 70%
so we adopt this value instead of our previous 80%.

Conversely, we slightly raise the cache discard threshold because it's OK for
those to be in memory and swapped to zram to some extent if other apps are
being used, within reason. Our previous value was 45%, Chrome OS's "aggressive
cache discard" level is 35% and the default is 60%. Because Endless OS has more
overhead than Chrome OS, and other apps are more likely to be loaded, try 50%
and see if we need to reduce it if low-memory machines feel a bit slow.

https://phabricator.endlessm.com/T23137