### PR TITLE
Fix User Agent string replacements for ARM

### DIFF
--- a/content/browser/frame_host/navigation_request.cc
+++ b/content/browser/frame_host/navigation_request.cc
@@ -178,7 +178,7 @@ std::string AdaptUserAgentForURL(const std::string& user_agent, const GURL& url)
       (host.find("google.com") != std::string::npos && url.path().find("/calendar") == 0) ||
       url.DomainIs("netflix.com") ||
       url.DomainIs("nflxvideo.net")) {
-    std::string::size_type start_pos = user_agent.find('(');
+    std::string::size_type start_pos = user_agent.find('(') + 1;
     std::string::size_type end_pos = user_agent.find(')');
     result.replace(start_pos, end_pos - start_pos, std::string("X11; CrOS armv7l 10575.54.0"));
   }


### PR DESCRIPTION
The string replacement that was being applied to Netflix and Google
Calendar for ARM was stripping out the initial parentheses, breaking
the expected modification.

https://phabricator.endlessm.com/T23608