### PR TITLE
Make sure to fallback to VDA1 if mojo video decoder is disabled at buildtime

### DIFF
--- a/content/browser/media/key_system_support_impl.cc
+++ b/content/browser/media/key_system_support_impl.cc
@@ -20,6 +20,7 @@
 #include "media/base/key_system_names.h"
 #include "media/base/key_systems.h"
 #include "media/base/media_switches.h"
+#include "media/mojo/buildflags.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 
 namespace content {
@@ -114,11 +115,17 @@ void GetHardwareSecureDecryptionCaps(
     return;
   }
 
+#if BUILDFLAG(ENABLE_MOJO_VIDEO_DECODER)
   if (!base::FeatureList::IsEnabled(media::kMojoVideoDecoder)) {
     DVLOG(1) << "Hardware secure codecs not supported because mojo video "
-                "decode disabled";
+                "decode was disabled at runtime";
     return;
   }
+#else
+  DVLOG(1) << "Hardware secure codecs not supported because mojo video "
+              "decode was disabled at buildtime";
+  return;
+#endif
 
   base::flat_set<media::VideoCodec> video_codec_set;
   base::flat_set<media::EncryptionMode> encryption_scheme_set;

--- a/media/renderers/default_decoder_factory.cc
+++ b/media/renderers/default_decoder_factory.cc
@@ -97,14 +97,13 @@ void DefaultDecoderFactory::CreateVideoDecoders(
     // factories, require that their message loops are identical.
     DCHECK_EQ(gpu_factories->GetTaskRunner(), task_runner);
 
-    if (external_decoder_factory_) {
+    // MojoVideoDecoder replaces any VDA for this platform when it's enabled.
+    if (external_decoder_factory_ &&
+        base::FeatureList::IsEnabled(media::kMojoVideoDecoder)) {
       external_decoder_factory_->CreateVideoDecoders(
           task_runner, gpu_factories, media_log, request_overlay_info_cb,
           target_color_space, video_decoders);
-    }
-
-    // MojoVideoDecoder replaces any VDA for this platform when it's enabled.
-    if (!base::FeatureList::IsEnabled(media::kMojoVideoDecoder)) {
+    } else {
       video_decoders->push_back(std::make_unique<GpuVideoDecoder>(
           gpu_factories, request_overlay_info_cb, target_color_space,
           media_log));


### PR DESCRIPTION
Also avoids a few ipc round trips when mojo video decoder is enabled
at buildtime but disabled at runtime.
Previously external_decoder_factory_->CreateVideoDecoders was still
called in that case.

Tested on Linux desktop with gn args:
  - use_vaapi = true (default is false)
  - enable_mojo_media = false (default is also false)
  ./out/release/chrome --ignore-gpu-blacklist --use-gl=desktop url_to_vp9_video
  ./out/release/chrome --ignore-gpu-blacklist --use-gl=egl url_to_vp9_video
  -> GpuVideoDecoder (VDA1) was in use

Bug: 522298
Change-Id: Ia7566877f76da8d108d8993c57c6d29d745cfa8a
Reviewed-on: https://chromium-review.googlesource.com/c/1374741
Reviewed-by: Dan Sanders <sandersd@chromium.org>
Commit-Queue: Julien Isorce <julien.isorce@chromium.org>
Cr-Commit-Position: refs/heads/master@{#616855}

https://phabricator.endlessm.com/T25531