### PR TITLE
Skip parental controls check when packing extensions

### DIFF
--- a/debian/chromium-browser.sh.in
+++ b/debian/chromium-browser.sh.in
@@ -7,11 +7,25 @@
 #  Fabien Tassin <fta@sofaraway.org>
 # License: GPLv2 or later
 
-ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+enforce_parental_controls=true
+for i in "$@"; do
+  case "$i" in
+    --pack-extension|--pack-extension=* )
+      # Skip parental controls check if packing extensions
+      enforce_parental_controls=false
+      break ;;
+    * )
+      ;;
+  esac
+done
 
-if ! malcontent-client --quiet check --no-interactive ${ABSOLUTE_PATH}; then
-  echo "error: $ABSOLUTE_PATH is blacklisted for the current user" >&2
-  exit 1
+if $enforce_parental_controls; then
+  ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  if ! malcontent-client --quiet check --no-interactive ${ABSOLUTE_PATH}; then
+    echo "error: $ABSOLUTE_PATH is blacklisted for the current user" >&2
+    exit 1
+  fi
 fi
 
 PLUGIN_PARAMETERS=""


### PR DESCRIPTION
When packing extensions lets skip the parental controls check to avoid
malcontent-client to fail (and consider the app blacklisted) if access
to dbus system bus or AccountsService is not available.

Signed-off-by: Andre Moreira Magalhaes <andre@endlessm.com>

https://phabricator.endlessm.com/T26955