### PR TITLE
parental controls: Also filter by content type

### DIFF
--- a/debian/chromium-browser.sh.in
+++ b/debian/chromium-browser.sh.in
@@ -22,7 +22,8 @@ done
 if $enforce_parental_controls; then
   ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  if ! malcontent-client --quiet check --no-interactive ${ABSOLUTE_PATH}; then
+  if ! malcontent-client --quiet check --no-interactive ${ABSOLUTE_PATH} ||
+     ! malcontent-client --quiet check --no-interactive "x-scheme-handler/http"; then
     echo "error: $ABSOLUTE_PATH is blacklisted for the current user" >&2
     exit 1
   fi

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Pre-Depends: dpkg (>= 1.15.6)
 Depends: ${shlibs:Depends}, ${misc:Depends},
 	bash (>= 4),
 	libnss3,
-	malcontent-tools (>= 0.3.0+dev7.f611ec3-0),
+	malcontent-tools (>= 0.4.0),
 	netcat-openbsd (>= 1.110),
 	xdg-utils,
 	chromium-codecs-ffmpeg (= ${binary:Version}),


### PR DESCRIPTION
I decided to keep the filter by path check for 2 reasons:
- to make it easier to implement support for blacklisting individual browsers in case we decide to go that route in the future - see https://phabricator.endlessm.com/T26895#730545 for more details
- users can still blacklist the browser by path via D-Bus or via cmdline using malcontent-client, although this won't be possible for now (at least) via GNOME settings - see also https://github.com/endlessm/gnome-control-center/pull/182

Same reason why I kept the `X-Parental-Controls` key in the desktop file, which should have no effect with the current proposed changes to GNOME settings (see above), but may come handy if we decide to allow disabling browsers individually as well.

https://phabricator.endlessm.com/T26955