### PR TITLE
debian/control: Increase libfdk-aac-dev version dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Build-Depends:
 	libnss3-dev,
 	mesa-common-dev,
 	libnoopenh264-dev,
-	libfdk-aac-dev,
+	libfdk-aac-dev (>= 2.0.0),
 	libgles2-mesa-dev [armel armhf],
 	libpci-dev,
 	libxtst-dev,


### PR DESCRIPTION
The updated version of libfdk-aac provided by T27104 fixes an audio
glitch happening playing certain videos.

https://phabricator.endlessm.com/T21886