### PR TITLE
Enable VAVDA, VAVEA and VAJDA on linux with VAAPI only

### DIFF
--- a/chrome/browser/about_flags.cc
+++ b/chrome/browser/about_flags.cc
@@ -1450,7 +1450,7 @@ const FeatureEntry kFeatureEntries[] = {
         "disable-accelerated-video-decode",
         flag_descriptions::kAcceleratedVideoDecodeName,
         flag_descriptions::kAcceleratedVideoDecodeDescription,
-        kOsMac | kOsWin | kOsCrOS | kOsAndroid,
+        kOsAll,
         SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedVideoDecode),
     },
     {"enable-history-favicons-google-server-query",
@@ -1883,10 +1883,10 @@ const FeatureEntry kFeatureEntries[] = {
      FEATURE_VALUE_TYPE(service_manager::features::kXRSandbox)},
 #endif  // ENABLE_ISOLATED_XR_SERVICE
 #endif  // ENABLE_VR
-#if defined(OS_CHROMEOS)
+#if defined(OS_LINUX) && !defined(OS_ANDROID)
     {"disable-accelerated-mjpeg-decode",
      flag_descriptions::kAcceleratedMjpegDecodeName,
-     flag_descriptions::kAcceleratedMjpegDecodeDescription, kOsCrOS,
+     flag_descriptions::kAcceleratedMjpegDecodeDescription, kOsCrOS | kOsLinux,
      SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedMjpegDecode)},
 #endif  // OS_CHROMEOS
     {"system-keyboard-lock", flag_descriptions::kSystemKeyboardLockName,

--- a/chrome/browser/flag_descriptions.cc
+++ b/chrome/browser/flag_descriptions.cc
@@ -2766,15 +2766,19 @@ const char kMacSystemMediaPermissionsInfoUiDescription[] =
 
 #endif
 
-// Chrome OS -------------------------------------------------------------------
-
-#if defined(OS_CHROMEOS)
+#if defined(OS_LINUX) && !defined(OS_ANDROID)
 
 const char kAcceleratedMjpegDecodeName[] =
     "Hardware-accelerated mjpeg decode for captured frame";
 const char kAcceleratedMjpegDecodeDescription[] =
     "Enable hardware-accelerated mjpeg decode for captured frame where "
     "available.";
+
+#endif
+
+// Chrome OS -------------------------------------------------------------------
+
+#if defined(OS_CHROMEOS)
 
 const char kAppServiceAshName[] = "App Service Ash";
 const char kAppServiceAshDescription[] =

--- a/chrome/browser/flag_descriptions.h
+++ b/chrome/browser/flag_descriptions.h
@@ -1645,12 +1645,16 @@ extern const char kPermissionPromptPersistenceToggleDescription[];
 
 #endif  // defined(OS_MACOSX)
 
-// Chrome OS ------------------------------------------------------------------
-
-#if defined(OS_CHROMEOS)
+#if defined(OS_LINUX) && !defined(OS_ANDROID)
 
 extern const char kAcceleratedMjpegDecodeName[];
 extern const char kAcceleratedMjpegDecodeDescription[];
+
+#endif
+
+// Chrome OS ------------------------------------------------------------------
+
+#if defined(OS_CHROMEOS)
 
 extern const char kAppServiceAshName[];
 extern const char kAppServiceAshDescription[];

--- a/content/gpu/BUILD.gn
+++ b/content/gpu/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/config/jumbo.gni")
 import("//build/config/ui.gni")
 import("//gpu/vulkan/features.gni")
 import("//media/media_options.gni")
+import("//media/gpu/args.gni")
 import("//ui/ozone/ozone.gni")
 
 # See //content/BUILD.gn for how this works.
@@ -126,5 +127,9 @@ target(link_target_type, "gpu_sources") {
   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_desktop_linux &&
       (!is_chromecast || is_cast_desktop_build)) {
     configs += [ "//build/config/linux/dri" ]
+  }
+
+  if (is_desktop_linux && use_vaapi) {
+    public_configs = [ "//build/config/linux/libva" ]
   }
 }

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -523,7 +523,7 @@ bool IsVideoCaptureAcceleratedJpegDecodingEnabled() {
           switches::kUseFakeMjpegDecodeAccelerator)) {
     return true;
   }
-#if defined(OS_CHROMEOS)
+#if defined(OS_LINUX) && !defined(OS_ANDROID)
   return true;
 #endif
   return false;

--- a/media/filters/BUILD.gn
+++ b/media/filters/BUILD.gn
@@ -5,6 +5,7 @@
 import("//build/config/jumbo.gni")
 import("//media/media_options.gni")
 import("//third_party/libaom/options.gni")
+import("//media/gpu/args.gni")
 
 jumbo_source_set("filters") {
   # Do not expand the visibility here without double-checking with OWNERS, this
@@ -199,7 +200,7 @@ jumbo_source_set("filters") {
     deps += [ "//media/base/android" ]
   }
 
-  if (current_cpu != "arm" && is_linux) {
+  if (use_vaapi) {
     sources += [
       "h264_bitstream_buffer.cc",
       "h264_bitstream_buffer.h",

--- a/media/gpu/BUILD.gn
+++ b/media/gpu/BUILD.gn
@@ -525,6 +525,7 @@ if (use_v4l2_codec || use_vaapi || is_mac || is_win) {
     if (use_ozone) {
       deps += [ "//ui/ozone" ]
     }
+    public_configs = [ "//build/config/linux/libva" ]
   }
 }
 

--- a/media/gpu/gpu_video_decode_accelerator_factory.cc
+++ b/media/gpu/gpu_video_decode_accelerator_factory.cc
@@ -183,6 +183,8 @@ GpuVideoDecodeAcceleratorFactory::CreateVDA(
     vda = (this->*create_vda_function)(workarounds, gpu_preferences, media_log);
     if (vda && vda->Initialize(config, client))
       return vda;
+    else
+      LOG(ERROR) << "Initialization of one or more VDAs failed.";
   }
 
   return nullptr;
@@ -243,6 +245,7 @@ GpuVideoDecodeAcceleratorFactory::CreateVaapiVDA(
     const gpu::GpuDriverBugWorkarounds& workarounds,
     const gpu::GpuPreferences& gpu_preferences,
     MediaLog* media_log) const {
+  LOG(WARNING) << "Initializing VAAPI VDA.";
   std::unique_ptr<VideoDecodeAccelerator> decoder;
   decoder.reset(new VaapiVideoDecodeAccelerator(make_context_current_cb_,
                                                 bind_image_cb_));

--- a/media/gpu/ipc/service/gpu_video_decode_accelerator.cc
+++ b/media/gpu/ipc/service/gpu_video_decode_accelerator.cc
@@ -381,6 +381,7 @@ bool GpuVideoDecodeAccelerator::Initialize(
     LOG(ERROR) << "Failed creating the VDA factory";
     return false;
   }
+  LOG(WARNING) << "Created the VDA factory";
 
   const gpu::GpuDriverBugWorkarounds& gpu_workarounds =
       stub_->channel()->gpu_channel_manager()->gpu_driver_bug_workarounds();
@@ -394,6 +395,7 @@ bool GpuVideoDecodeAccelerator::Initialize(
                << (config.is_encrypted() ? " with encryption" : "");
     return false;
   }
+  LOG(WARNING) << "Created VDA";
 
   // Attempt to set up performing decoding tasks on IO thread, if supported by
   // the VDA.

--- a/media/gpu/vaapi/vaapi_wrapper.cc
+++ b/media/gpu/vaapi/vaapi_wrapper.cc
@@ -250,6 +250,11 @@ void VADisplayState::PreSandboxInitialization() {
       base::File::FLAG_OPEN | base::File::FLAG_READ | base::File::FLAG_WRITE);
   if (drm_file.IsValid())
     VADisplayState::Get()->SetDrmFd(drm_file.GetPlatformFile());
+
+  const char kNvidiaPath[] = "/dev/dri/nvidiactl";
+  base::File nvidia_file = base::File(
+      base::FilePath::FromUTF8Unsafe(kNvidiaPath),
+      base::File::FLAG_OPEN | base::File::FLAG_READ | base::File::FLAG_WRITE);
 }
 
 VADisplayState::VADisplayState()
@@ -277,9 +282,6 @@ bool VADisplayState::Initialize() {
 }
 
 bool VADisplayState::InitializeOnce() {
-  static_assert(VA_MAJOR_VERSION >= 1 && VA_MINOR_VERSION >= 1,
-                "Requires VA-API >= 1.1.0");
-
   switch (gl::GetGLImplementation()) {
     case gl::kGLImplementationEGLGLES2:
       va_display_ = vaGetDisplayDRM(drm_fd_.get());
@@ -287,10 +289,10 @@ bool VADisplayState::InitializeOnce() {
     case gl::kGLImplementationDesktopGL:
 #if defined(USE_X11)
       va_display_ = vaGetDisplay(gfx::GetXDisplay());
-#else
-      LOG(WARNING) << "VAAPI video acceleration not available without "
-                      "DesktopGL (GLX).";
+      if (vaDisplayIsValid(va_display_))
+        break;
 #endif  // USE_X11
+      va_display_ = vaGetDisplayDRM(drm_fd_.get());
       break;
     // Cannot infer platform from GL, try all available displays
     case gl::kGLImplementationNone:
@@ -323,8 +325,19 @@ bool VADisplayState::InitializeOnce() {
   int major_version, minor_version;
   VAStatus va_res = vaInitialize(va_display_, &major_version, &minor_version);
   if (va_res != VA_STATUS_SUCCESS) {
-    LOG(ERROR) << "vaInitialize failed: " << vaErrorStr(va_res);
-    return false;
+    LOG(ERROR) << "vaInitialize failed (ignore if using Wayland desktop environment): " << vaErrorStr(va_res);
+    va_display_ = vaGetDisplayDRM(drm_fd_.get());
+    if (!vaDisplayIsValid(va_display_)) {
+      LOG(ERROR) << "Could not get a valid DRM VA display";
+      return false;
+    }
+    va_res = vaInitialize(va_display_, &major_version, &minor_version);
+    if (va_res != VA_STATUS_SUCCESS) {
+      LOG(ERROR) << "vaInitialize failed using DRM: " << vaErrorStr(va_res);
+      return false;
+    } else {
+      LOG(WARNING) << "vaInitialize succeeded for DRM";
+    }
   }
 
   va_initialized_ = true;
@@ -332,7 +345,7 @@ bool VADisplayState::InitializeOnce() {
   va_vendor_string_ = vaQueryVendorString(va_display_);
   DLOG_IF(WARNING, va_vendor_string_.empty())
       << "Vendor string empty or error reading.";
-  DVLOG(1) << "VAAPI version: " << major_version << "." << minor_version << " "
+  VLOG(1) << "VAAPI version: " << major_version << "." << minor_version << " "
            << va_vendor_string_;
 
   // The VAAPI version is determined from what is loaded on the system by
@@ -665,7 +678,7 @@ bool VASupportedProfiles::AreAttribsSupported_Locked(
     if (attribs[i].type != required_attribs[i].type ||
         (attribs[i].value & required_attribs[i].value) !=
             required_attribs[i].value) {
-      DVLOG(1) << "Unsupported value " << required_attribs[i].value
+      VLOG(1) << "Unsupported value " << required_attribs[i].value
                << " for attribute type " << required_attribs[i].type;
       return false;
     }


### PR DESCRIPTION
This patch contains all the changes necessary to use VA-API along with vaapi-driver to run all media use cases supported with hardware acceleration.

https://phabricator.endlessm.com/T24548