### PR TITLE
Enable VAAPI accelerated video

### DIFF
--- a/debian/chromium-browser.default.amd64
+++ b/debian/chromium-browser.default.amd64
@@ -1,0 +1,5 @@
+# Default settings for chromium-browser. This file is sourced by /bin/sh from
+# /usr/bin/chromium-browser
+
+# Options to pass to chromium-browser
+CHROMIUM_FLAGS="--enable-accelerated-video"

--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,7 @@ Build-Depends:
 	libxkbcommon-dev,
 	libpam0g-dev,
 	libffi-dev,
+	libva-dev,
 	uuid-dev,
 	chrpath,
 	yasm

--- a/debian/rules
+++ b/debian/rules
@@ -141,6 +141,7 @@ else ifeq (i386,$(DEB_HOST_ARCH))
 common_defines += target_cpu="x86"
 else ifeq (amd64,$(DEB_HOST_ARCH))
 common_defines += target_cpu="x64"
+common_defines += use_vaapi=true
 else ifeq (mipsel,$(DEB_HOST_ARCH))
 common_defines += target_cpu="mipsel"
 else ifeq ($(DEB_HOST_ARCH),)
@@ -329,7 +330,12 @@ override_dh_install-arch:
 	mkdir -p debian/chromium-chromedriver/usr/bin
 	mkdir -p debian/chromium-browser/$(LIB_DIR)
 
+	# Endless: Set different runtime flags for VA-API on Intel
+ifeq (amd64,$(DEB_HOST_ARCH))
+	install -T -m 644 debian/chromium-browser.default.amd64 debian/chromium-browser/etc/chromium-browser/default
+else
 	install -T -m 644 debian/chromium-browser.default debian/chromium-browser/etc/chromium-browser/default
+endif
 
 	# Convert rpath to runpath if needed, so that LD_LIBRARY_PATH (set in our launcher script)
 	# takes precedence. This is required for Endless extra codecs to work properly.


### PR DESCRIPTION
Add libva-dev to debian/control, set use_vaapi=true for amd64 and set up default '--enable-accelerated-video' on that arch.

https://phabricator.endlessm.com/T24548