### PR TITLE
ffmpeg: Fix AAC playback on free version

### DIFF
--- a/third_party/ffmpeg/chromium/config/Chromium/linux/x64/libavformat/demuxer_list.c
+++ b/third_party/ffmpeg/chromium/config/Chromium/linux/x64/libavformat/demuxer_list.c
@@ -1,4 +1,5 @@
 static const AVInputFormat * const demuxer_list[] = {
+    &ff_aac_demuxer,
     &ff_flac_demuxer,
     &ff_matroska_demuxer,
     &ff_mov_demuxer,

--- a/third_party/ffmpeg/ffmpeg_generated.gni
+++ b/third_party/ffmpeg/ffmpeg_generated.gni
@@ -219,6 +219,15 @@ if ((current_cpu == "x64" && ffmpeg_branding == "Chrome") || (is_android && curr
   ]
 }
 
+# EndlessOS: Modified to also build the AAC demuxer for the "free" version
+if ((current_cpu == "x64" && ffmpeg_branding == "Chromium")) {
+  ffmpeg_c_sources += [
+    "libavformat/aacdec.c",
+    "libavformat/apetag.c",
+    "libavformat/img2.c",
+  ]
+}
+
 if ((is_mac && ffmpeg_branding == "Chrome") || (is_win && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "Chrome") || (use_linux_config && ffmpeg_branding == "ChromeOS")) {
   ffmpeg_c_sources += [
     "libavcodec/cabac.c",


### PR DESCRIPTION
This fixes an issue with the "free" version of ffmpeg where although
fdk-aac is enabled, the AAC demuxer is missing and thus causing chromium
to not recognize/fail to parse some AAC audio content.

See https://phabricator.endlessm.com/T21886#753245 for more details.

https://phabricator.endlessm.com/T21886