### PR TITLE
debian: Fix use of renamed malcontent-client API

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+chromium-browser (79.0.3945.130-0endless1) eos; urgency=medium
+
+  * Fix use of renamed malcontent-client API and bump the malcontent-tools
+    dependency (T29195)
+
+ -- Philip Withnall <withnall@endlessm.com>  Thu, 23 Jan 2020 13:45:00 +0000
+
 chromium-browser (79.0.3945.130-0endless0) eos; urgency=medium
 
   * Upstream release: 79.0.3945.130

--- a/debian/chromium-browser.sh.in
+++ b/debian/chromium-browser.sh.in
@@ -22,8 +22,8 @@ done
 if $enforce_parental_controls; then
   ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  if ! malcontent-client --quiet check --no-interactive ${ABSOLUTE_PATH} ||
-     ! malcontent-client --quiet check --no-interactive "x-scheme-handler/http"; then
+  if ! malcontent-client --quiet check-app-filter --no-interactive ${ABSOLUTE_PATH} ||
+     ! malcontent-client --quiet check-app-filter --no-interactive "x-scheme-handler/http"; then
     echo "error: $ABSOLUTE_PATH is blacklisted for the current user" >&2
     exit 1
   fi

--- a/debian/control
+++ b/debian/control
@@ -52,7 +52,7 @@ Pre-Depends: dpkg (>= 1.15.6)
 Depends: ${shlibs:Depends}, ${misc:Depends},
 	bash (>= 4),
 	libnss3,
-	malcontent-tools (>= 0.4.0),
+	malcontent-tools (>= 0.4.0+dev43.13a1e20-5),
 	netcat-openbsd (>= 1.110),
 	xdg-utils,
 	chromium-codecs-ffmpeg (= ${binary:Version}),


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29195