### PR TITLE
Don't special case exploration center extension

### DIFF
--- a/chrome/common/extensions/manifest_handlers/extension_action_handler.cc
+++ b/chrome/common/extensions/manifest_handlers/extension_action_handler.cc
@@ -75,9 +75,6 @@ bool ExtensionActionHandler::Parse(Extension* extension,
     if (extension->was_installed_by_default())
       return true;  // Don't synthesize actions for default extensions.
 
-    if (extension->is_endless_os())
-      return true; // Don't synthesize actions for our Exploration Center extension.
-
     // Set an empty page action. We use a page action (instead of a browser
     // action) because the action should not be seen as enabled on every page.
     auto action_info = std::make_unique<ActionInfo>(ActionInfo::TYPE_PAGE);

--- a/extensions/common/extension.cc
+++ b/extensions/common/extension.cc
@@ -459,13 +459,6 @@ bool Extension::is_login_screen_extension() const {
   return manifest()->is_login_screen_extension();
 }
 
-bool Extension::is_endless_os() const {
-  if (manifest_->extension_id() == "fpmnjlkappdkncfmjefheaidpmbmfdfk")
-    return true; // EOS Exploration Center.
-
-  return false;
-}
-
 void Extension::AddWebExtentPattern(const URLPattern& pattern) {
   // Bookmark apps are permissionless.
   if (from_bookmark())

--- a/extensions/common/extension.h
+++ b/extensions/common/extension.h
@@ -326,7 +326,6 @@ class Extension : public base::RefCountedThreadSafe<Extension> {
   bool is_shared_module() const;        // Shared module
   bool is_theme() const;                // Theme
   bool is_login_screen_extension() const;  // Extension on login screen.
-  bool is_endless_os() const;
 
   // True if this is a platform app, hosted app, or legacy packaged app.
   bool is_app() const;


### PR DESCRIPTION
We are removing the exploration center extension on 3.9.

https://phabricator.endlessm.com/T30720